### PR TITLE
Add missing bootstage tag to ESI

### DIFF
--- a/config/SOMANET_CiA_402.xml
+++ b/config/SOMANET_CiA_402.xml
@@ -4995,6 +4995,7 @@
         <Eeprom>
           <ByteSize>15360</ByteSize>
           <ConfigData>080E028800000000000000000000</ConfigData>
+          <BootStrap>0010000400140004</BootStrap>
         </Eeprom>
       </Device>
     </Devices>


### PR DESCRIPTION
This tag is necessary so the master knows the mailbox configuration
to use during BootStrap mode.