### PR TITLE
Hotfix for hotfix in sc_sncn_ethercat

### DIFF
--- a/device_configuration/SOMANET_CiA_402.xml
+++ b/device_configuration/SOMANET_CiA_402.xml
@@ -779,7 +779,7 @@
               </DataType>
               <DataType>
                 <Name>DT2003</Name>
-                <BitSize>121</BitSize>
+                <BitSize>128</BitSize>
                 <SubItem>
                   <SubIdx>0</SubIdx>
                   <Name>Number of entries</Name>
@@ -838,8 +838,8 @@
                 <SubItem>
                   <SubIdx>5</SubIdx>
                   <Name>Motor phases inverted</Name>
-                  <Type>BOOL</Type>
-                  <BitSize>1</BitSize>
+                  <Type>USINT</Type>
+                  <BitSize>8</BitSize>
                   <BitOffs>120</BitOffs>
                   <Flags>
                     <Access>ro</Access>
@@ -964,7 +964,7 @@
               </DataType>
               <DataType>
                 <Name>DT2005</Name>
-                <BitSize>113</BitSize>
+                <BitSize>120</BitSize>
                 <SubItem>
                   <SubIdx>0</SubIdx>
                   <Name>Number of entries</Name>
@@ -979,8 +979,8 @@
                 <SubItem>
                   <SubIdx>1</SubIdx>
                   <Name>Recuperation enabled</Name>
-                  <Type>BOOL</Type>
-                  <BitSize>1</BitSize>
+                  <Type>USINT</Type>
+                  <BitSize>8</BitSize>
                   <BitOffs>16</BitOffs>
                   <Flags>
                     <Access>rw</Access>
@@ -992,7 +992,7 @@
                   <Name>Min battery energy</Name>
                   <Type>UINT</Type>
                   <BitSize>16</BitSize>
-                  <BitOffs>17</BitOffs>
+                  <BitOffs>24</BitOffs>
                   <Flags>
                     <Access>rw</Access>
                     <Category>m</Category>
@@ -1003,7 +1003,7 @@
                   <Name>Max battery energy</Name>
                   <Type>UINT</Type>
                   <BitSize>16</BitSize>
-                  <BitOffs>33</BitOffs>
+                  <BitOffs>40</BitOffs>
                   <Flags>
                     <Access>rw</Access>
                     <Category>m</Category>
@@ -1014,7 +1014,7 @@
                   <Name>Min recuperation power</Name>
                   <Type>UINT</Type>
                   <BitSize>16</BitSize>
-                  <BitOffs>49</BitOffs>
+                  <BitOffs>56</BitOffs>
                   <Flags>
                     <Access>rw</Access>
                     <Category>m</Category>
@@ -1025,7 +1025,7 @@
                   <Name>Max recuperation power</Name>
                   <Type>UINT</Type>
                   <BitSize>16</BitSize>
-                  <BitOffs>65</BitOffs>
+                  <BitOffs>72</BitOffs>
                   <Flags>
                     <Access>rw</Access>
                     <Category>m</Category>
@@ -1036,7 +1036,7 @@
                   <Name>Minimum recuperation speed</Name>
                   <Type>UINT</Type>
                   <BitSize>16</BitSize>
-                  <BitOffs>81</BitOffs>
+                  <BitOffs>88</BitOffs>
                   <Flags>
                     <Access>rw</Access>
                     <Category>m</Category>
@@ -1047,7 +1047,7 @@
                   <Name>Maximum recuperation speed</Name>
                   <Type>UINT</Type>
                   <BitSize>16</BitSize>
-                  <BitOffs>97</BitOffs>
+                  <BitOffs>104</BitOffs>
                   <Flags>
                     <Access>rw</Access>
                     <Category>m</Category>
@@ -3178,7 +3178,7 @@
                 <Name>Motor Specific Settings</Name>
                 <Comment></Comment>
                 <Type>DT2003</Type>
-                <BitSize>121</BitSize>
+                <BitSize>128</BitSize>
                 <Info>
                   <SubItem>
                     <Name>Number of entries</Name>
@@ -3339,7 +3339,7 @@
                 <Name>Recuperation</Name>
                 <Comment></Comment>
                 <Type>DT2005</Type>
-                <BitSize>113</BitSize>
+                <BitSize>120</BitSize>
                 <Info>
                   <SubItem>
                     <Name>Number of entries</Name>


### PR DESCRIPTION
This little patch is necessary to keep the ESI in sync with the
generated object dictionary.