### PR TITLE
rename MOTOR_PHASES_CONFIGURATION in user_config.h and main.xc files,…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ sc_sncn_ethercat_drive Change Log
 -----
 
   * Fix issue with a the value of position control strategy
+  * Rename MOTOR_PHASES_CONFIGURATION in user_config.h and main.xc files
+  * Change phase inverted parameter to 0 normal and 1 inverted
 
 
 3.0.1

--- a/examples/app_demo_master_cyclic/sdo_config/sdo_config.csv
+++ b/examples/app_demo_master_cyclic/sdo_config/sdo_config.csv
@@ -10,7 +10,7 @@
 0x2003,        2,       60000,       60000,       60000,       60000,       60000,       60000 # DICT_MOTOR_SPECIFIC_SETTINGS TORQUE_CONSTANT
 0x2003,        3,      552000,      552000,      552000,      552000,      552000,      552000 # DICT_MOTOR_SPECIFIC_SETTINGS PHASE_RESISTANCE
 0x2003,        4,         720,         720,         720,         720,         720,         720 # DICT_MOTOR_SPECIFIC_SETTINGS PHASE_INDUCTANCE     
-0x2003,        5,           1,           1,           1,           1,           1,           1 # DICT_MOTOR_SPECIFIC_SETTINGS MOTOR_PHASES_INVERTED (1 normal, -1 inverted)
+0x2003,        5,           0,           0,           0,           0,           0,           0 # DICT_MOTOR_SPECIFIC_SETTINGS MOTOR_PHASES_INVERTED (0 normal, 1 inverted)
 
 #brake config
 0x2004,        1,       13000,       13000,       13000,       13000,       13000,       13000 # DICT_BREAK_RELEASE PULL_BRAKE_VOLTAGE
@@ -32,7 +32,7 @@
 #protection
 0x2006,        1,          10,          10,          10,          10,          10,          10 # DICT_PROTECTION MIN_DC_VOLTAGE
 0x2006,        2,          60,          60,          60,          60,          60,          60 # DICT_PROTECTION MAX_DC_VOLTAGE
-0x2006,        3,         100,         100,         100,         100,         100,         100 # DICT_PROTECTION MAX_CURRENT 
+0x2006,        3,      100000,      100000,      100000,      100000,      100000,      100000 # DICT_PROTECTION MAX_CURRENT 
 
 #torque position velocity control
 #main parameters

--- a/examples/app_demo_master_ethercat_tuning/sdo_config/sdo_config.csv
+++ b/examples/app_demo_master_ethercat_tuning/sdo_config/sdo_config.csv
@@ -10,7 +10,7 @@
 0x2003,        2,       60000,       60000,       60000,       60000,       60000,       60000 # DICT_MOTOR_SPECIFIC_SETTINGS TORQUE_CONSTANT
 0x2003,        3,      552000,      552000,      552000,      552000,      552000,      552000 # DICT_MOTOR_SPECIFIC_SETTINGS PHASE_RESISTANCE
 0x2003,        4,         720,         720,         720,         720,         720,         720 # DICT_MOTOR_SPECIFIC_SETTINGS PHASE_INDUCTANCE     
-0x2003,        5,           1,           1,           1,           1,           1,           1 # DICT_MOTOR_SPECIFIC_SETTINGS MOTOR_PHASES_INVERTED (1 normal, -1 inverted)
+0x2003,        5,           0,           0,           0,           0,           0,           0 # DICT_MOTOR_SPECIFIC_SETTINGS MOTOR_PHASES_INVERTED (0 normal, 1 inverted)
 
 #brake config
 0x2004,        1,       13000,       13000,       13000,       13000,       13000,       13000 # DICT_BREAK_RELEASE PULL_BRAKE_VOLTAGE
@@ -32,7 +32,7 @@
 #protection
 0x2006,        1,          10,          10,          10,          10,          10,          10 # DICT_PROTECTION MIN_DC_VOLTAGE
 0x2006,        2,          60,          60,          60,          60,          60,          60 # DICT_PROTECTION MAX_DC_VOLTAGE
-0x2006,        3,         100,         100,         100,         100,         100,         100 # DICT_PROTECTION MAX_CURRENT 
+0x2006,        3,      100000,      100000,      100000,      100000,      100000,      100000 # DICT_PROTECTION MAX_CURRENT 
 
 #torque position velocity control
 #main parameters

--- a/examples/app_demo_slave_ethercat_motorcontrol/src/main.xc
+++ b/examples/app_demo_slave_ethercat_motorcontrol/src/main.xc
@@ -190,7 +190,7 @@ int main(void)
                     MotorcontrolConfig motorcontrol_config;
 
                     motorcontrol_config.dc_bus_voltage =  DC_BUS_VOLTAGE;
-                    motorcontrol_config.phases_inverted = MOTOR_PHASES_NORMAL;
+                    motorcontrol_config.phases_inverted = MOTOR_PHASES_CONFIGURATION;
                     motorcontrol_config.torque_P_gain =  TORQUE_Kp;
                     motorcontrol_config.torque_I_gain =  TORQUE_Ki;
                     motorcontrol_config.torque_D_gain =  TORQUE_Kd;

--- a/module_ethercat_drive/src/config_manager.xc
+++ b/module_ethercat_drive/src/config_manager.xc
@@ -180,7 +180,7 @@ int cm_sync_config_motor_control(
     motorcontrol_config = i_torque_control.get_config();
 
     motorcontrol_config.dc_bus_voltage           = i_coe.get_object_value(DICT_BREAK_RELEASE, SUB_BREAK_RELEASE_DC_BUS_VOLTAGE);
-    motorcontrol_config.phases_inverted          = sext(i_coe.get_object_value(DICT_MOTOR_SPECIFIC_SETTINGS, SUB_MOTOR_SPECIFIC_SETTINGS_MOTOR_PHASES_INVERTED), 8);
+    motorcontrol_config.phases_inverted          = i_coe.get_object_value(DICT_MOTOR_SPECIFIC_SETTINGS, SUB_MOTOR_SPECIFIC_SETTINGS_MOTOR_PHASES_INVERTED);
     motorcontrol_config.torque_P_gain            = i_coe.get_object_value(DICT_TORQUE_CONTROLLER, SUB_TORQUE_CONTROLLER_CONTROLLER_KP);
     motorcontrol_config.torque_I_gain            = i_coe.get_object_value(DICT_TORQUE_CONTROLLER, SUB_TORQUE_CONTROLLER_CONTROLLER_KI);
     motorcontrol_config.torque_D_gain            = i_coe.get_object_value(DICT_TORQUE_CONTROLLER, SUB_TORQUE_CONTROLLER_CONTROLLER_KD);


### PR DESCRIPTION
… Change phase inverted parameter to 0 normal and 1 inverted

fix https://www.wrike.com/open.htm?id=153260757 and https://www.wrike.com/open.htm?id=153558725
- use milliamps for max current limit
- for phase inverted parameters use 0 for normal and 1 for inverted
- also fix the update of protection limits at runtime