### PR TITLE
add port declarations for C21

### DIFF
--- a/examples/app_demo_slave_ethercat_motorcontrol/src/main.xc
+++ b/examples/app_demo_slave_ethercat_motorcontrol/src/main.xc
@@ -44,6 +44,10 @@ port ?gpio_port_0 = SOMANET_IFM_GPIO_D0;
 port ?gpio_port_1 = SOMANET_IFM_GPIO_D1;
 port ?gpio_port_2 = SOMANET_IFM_GPIO_D2;
 port ?gpio_port_3 = SOMANET_IFM_GPIO_D3;
+#ifdef CORE_C21_DX_G2 /* ports for the C21-DX-G2 */
+port c21watchdog = WD_PORT_TICK;
+port c21led = LED_PORT_4BIT_X_nG_nB_nR;
+#endif
 
 int main(void)
 {


### PR DESCRIPTION
Those port declaration are necessary for C21.
There are inside an ifdef so they will only be declared when C21 is used.
The app_demo_slave_ethercat_motorcontrol is still set to use C21 so to use C1 the Makefile and main.xc file need to be edited.