### PR TITLE
fix qei index type values to use 2 for two channels (AB) and 3 for th…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,9 +50,8 @@ examples/libreadsdoconfig/testreadconfig
 
 # ignore profiler files
 *.gprof
-*.inc
 *.sh
 *.log
-record.csv
+*.csv
 config_motor
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 sc_sncn_ethercat_drive Change Log
 ==================================
 
+3.0.3
+-----
+
+  * Fix torque offset pdo unit (now in 1/1000 of rated torque)
+  * Fix value of Encoder Number of Channels to 2 for AB and 3 for ABI.
+
+
 3.0.2
 -----
 

--- a/examples/app_demo_master_cyclic/sdo_config/sdo_config.csv
+++ b/examples/app_demo_master_cyclic/sdo_config/sdo_config.csv
@@ -64,7 +64,7 @@
 0x2201,        2,           1,           1,           1,           1,           1,           1 # ENCODER_FUNCTION - 0: Disabled, 1: Commutation and motion control, 2: Commutation and feedback display only, 3: Motion Control, 4: Feedback display only, 5: Commutation only
 0x2201,        3,      262144,      262144,      262144,      262144,      262144,      262144 # ENCODER_RESOLUTION [encoder increments (ticks)]
 0x2201,        4,          50,          50,          50,          50,          50,          50 # ENCODER_VELOCITY_CALCULATION_PERIOD [usec]
-0x2201,        5,          0,            0,           0,           0,           0,           0 # ENCODER_POLARITY (0 normal,  1 inverted)
+0x2201,        5,           0,           0,           0,           0,           0,           0 # ENCODER_POLARITY (0 normal,  1 inverted)
 0x2201,        6,          10,          10,          10,          10,          10,          10 # BISS_ENCODER_MULTITURN_RESOLUTION [bits]
 0x2201,        7,        4000,        4000,        4000,        4000,        4000,        4000 # BISS_ENCODER_CLOCK_FREQUENCY [Hz]
 0x2201,        8,          20,          20,          20,          20,          20,          20 # BISS_ENCODER_TIMEOUT - BiSS timeout in [usec]
@@ -78,7 +78,7 @@
 0x2202,        2,           1,           1,           1,           1,           1,           1 # ENCODER_FUNCTION - 0: Disabled, 1: Commutation and motion control, 2: Commutation and feedback display only, 3: Motion Control, 4: Feedback display only, 5: Commutation only
 0x2202,        3,      262144,      262144,      262144,      262144,      262144,      262144 # ENCODER_RESOLUTION [encoder increments (ticks)]
 0x2202,        4,          50,          50,          50,          50,          50,          50 # ENCODER_VELOCITY_CALCULATION_PERIOD [usec]
-0x2202,        5,          0,            0,           0,           0,           0,           0 # ENCODER_POLARITY (0 normal,  1 inverted)
+0x2202,        5,           0,           0,           0,           0,           0,           0 # ENCODER_POLARITY (0 normal,  1 inverted)
 0x2202,        6,          10,          10,          10,          10,          10,          10 # BISS_ENCODER_MULTITURN_RESOLUTION [bits]
 0x2202,        7,        4000,        4000,        4000,        4000,        4000,        4000 # BISS_ENCODER_CLOCK_FREQUENCY [Hz]
 0x2202,        8,          20,          20,          20,          20,          20,          20 # BISS_ENCODER_TIMEOUT - BiSS timeout in [usec]
@@ -110,7 +110,7 @@
 0x2205,        3,        4000,        4000,        4000,        4000,        4000,      262144 # ENCODER_RESOLUTION [encoder increments (ticks)]
 0x2205,        4,        1000,        1000,        1000,        1000,        1000,        1000 # ENCODER_VELOCITY_CALCULATION_PERIOD [usec]
 0x2205,        5,           0,           0,           0,           0,           0,           0 # ENCODER_POLARITY (0 normal,  1 inverted)
-0x2205,        6,           1,           1,           1,           1,           1,           1 # ENCODER_NUMBER_OF_CHANNELS [0:1] - 0: AB (2 channels), 1: ABI (3 channels)
+0x2205,        6,           3,           3,           3,           3,           3,           3 # ENCODER_NUMBER_OF_CHANNELS [2:3] - 2: AB (2 channels), 3: ABI (3 channels)
 0x2205,        7,           0,           0,           0,           0,           0,           0 # ENCODER_SENSOR_SIGNAL_TYPE [0:1] - 0: RS422, 1: TTL
 #Incremental Encoder 2
 0x2206,        1,           2,           2,           2,           2,           2,           2 # SENSOR TYPE (2 is Incremental Encoder)
@@ -118,7 +118,7 @@
 0x2206,        3,        4000,        4000,        4000,        4000,        4000,      262144 # ENCODER_RESOLUTION [encoder increments (ticks)]
 0x2206,        4,        1000,        1000,        1000,        1000,        1000,        1000 # ENCODER_VELOCITY_CALCULATION_PERIOD [usec]
 0x2206,        5,           0,           0,           0,           0,           0,           0 # ENCODER_POLARITY (0 normal,  1 inverted)
-0x2206,        6,           1,           1,           1,           1,           1,           1 # ENCODER_NUMBER_OF_CHANNELS [0:1] - 0: AB (2 channels), 1: ABI (3 channels)
+0x2205,        6,           3,           3,           3,           3,           3,           3 # ENCODER_NUMBER_OF_CHANNELS [2:3] - 2: AB (2 channels), 3: ABI (3 channels)
 0x2206,        7,           0,           0,           0,           0,           0,           0 # ENCODER_SENSOR_SIGNAL_TYPE [0:1] - 0: RS422, 1: TTL
 #hall sensor 1
 0x2207,        1,           1,           1,           1,           1,           1,           1 # SENSOR TYPE (1 is Hall)

--- a/examples/app_demo_master_ethercat_tuning/sdo_config/sdo_config.csv
+++ b/examples/app_demo_master_ethercat_tuning/sdo_config/sdo_config.csv
@@ -64,7 +64,7 @@
 0x2201,        2,           1,           1,           1,           1,           1,           1 # ENCODER_FUNCTION - 0: Disabled, 1: Commutation and motion control, 2: Commutation and feedback display only, 3: Motion Control, 4: Feedback display only, 5: Commutation only
 0x2201,        3,      262144,      262144,      262144,      262144,      262144,      262144 # ENCODER_RESOLUTION [encoder increments (ticks)]
 0x2201,        4,          50,          50,          50,          50,          50,          50 # ENCODER_VELOCITY_CALCULATION_PERIOD [usec]
-0x2201,        5,          0,            0,           0,           0,           0,           0 # ENCODER_POLARITY (0 normal,  1 inverted)
+0x2201,        5,           0,           0,           0,           0,           0,           0 # ENCODER_POLARITY (0 normal,  1 inverted)
 0x2201,        6,          10,          10,          10,          10,          10,          10 # BISS_ENCODER_MULTITURN_RESOLUTION [bits]
 0x2201,        7,        4000,        4000,        4000,        4000,        4000,        4000 # BISS_ENCODER_CLOCK_FREQUENCY [Hz]
 0x2201,        8,          20,          20,          20,          20,          20,          20 # BISS_ENCODER_TIMEOUT - BiSS timeout in [usec]
@@ -78,7 +78,7 @@
 0x2202,        2,           1,           1,           1,           1,           1,           1 # ENCODER_FUNCTION - 0: Disabled, 1: Commutation and motion control, 2: Commutation and feedback display only, 3: Motion Control, 4: Feedback display only, 5: Commutation only
 0x2202,        3,      262144,      262144,      262144,      262144,      262144,      262144 # ENCODER_RESOLUTION [encoder increments (ticks)]
 0x2202,        4,          50,          50,          50,          50,          50,          50 # ENCODER_VELOCITY_CALCULATION_PERIOD [usec]
-0x2202,        5,          0,            0,           0,           0,           0,           0 # ENCODER_POLARITY (0 normal,  1 inverted)
+0x2202,        5,           0,           0,           0,           0,           0,           0 # ENCODER_POLARITY (0 normal,  1 inverted)
 0x2202,        6,          10,          10,          10,          10,          10,          10 # BISS_ENCODER_MULTITURN_RESOLUTION [bits]
 0x2202,        7,        4000,        4000,        4000,        4000,        4000,        4000 # BISS_ENCODER_CLOCK_FREQUENCY [Hz]
 0x2202,        8,          20,          20,          20,          20,          20,          20 # BISS_ENCODER_TIMEOUT - BiSS timeout in [usec]
@@ -110,7 +110,7 @@
 0x2205,        3,        4000,        4000,        4000,        4000,        4000,      262144 # ENCODER_RESOLUTION [encoder increments (ticks)]
 0x2205,        4,        1000,        1000,        1000,        1000,        1000,        1000 # ENCODER_VELOCITY_CALCULATION_PERIOD [usec]
 0x2205,        5,           0,           0,           0,           0,           0,           0 # ENCODER_POLARITY (0 normal,  1 inverted)
-0x2205,        6,           1,           1,           1,           1,           1,           1 # ENCODER_NUMBER_OF_CHANNELS [0:1] - 0: AB (2 channels), 1: ABI (3 channels)
+0x2205,        6,           3,           3,           3,           3,           3,           3 # ENCODER_NUMBER_OF_CHANNELS [2:3] - 2: AB (2 channels), 3: ABI (3 channels)
 0x2205,        7,           0,           0,           0,           0,           0,           0 # ENCODER_SENSOR_SIGNAL_TYPE [0:1] - 0: RS422, 1: TTL
 #Incremental Encoder 2
 0x2206,        1,           2,           2,           2,           2,           2,           2 # SENSOR TYPE (2 is Incremental Encoder)
@@ -118,7 +118,7 @@
 0x2206,        3,        4000,        4000,        4000,        4000,        4000,      262144 # ENCODER_RESOLUTION [encoder increments (ticks)]
 0x2206,        4,        1000,        1000,        1000,        1000,        1000,        1000 # ENCODER_VELOCITY_CALCULATION_PERIOD [usec]
 0x2206,        5,           0,           0,           0,           0,           0,           0 # ENCODER_POLARITY (0 normal,  1 inverted)
-0x2206,        6,           1,           1,           1,           1,           1,           1 # ENCODER_NUMBER_OF_CHANNELS [0:1] - 0: AB (2 channels), 1: ABI (3 channels)
+0x2205,        6,           3,           3,           3,           3,           3,           3 # ENCODER_NUMBER_OF_CHANNELS [2:3] - 2: AB (2 channels), 3: ABI (3 channels)
 0x2206,        7,           0,           0,           0,           0,           0,           0 # ENCODER_SENSOR_SIGNAL_TYPE [0:1] - 0: RS422, 1: TTL
 #hall sensor 1
 0x2207,        1,           1,           1,           1,           1,           1,           1 # SENSOR TYPE (1 is Hall)

--- a/module_ethercat_drive/src/ethercat_drive_service.xc
+++ b/module_ethercat_drive/src/ethercat_drive_service.xc
@@ -466,7 +466,7 @@ void ethercat_drive_service(ProfilerConfig &profiler_config,
         target_position = pdo_get_target_position(InOut);
         target_velocity = pdo_get_target_velocity(InOut);
         target_torque   = (pdo_get_target_torque(InOut)*motorcontrol_config.rated_torque) / 1000; //target torque received in 1/1000 of rated torque
-        send_to_control.offset_torque = pdo_get_offset_torque(InOut); /* FIXME send this to the controll */
+        send_to_control.offset_torque = (pdo_get_offset_torque(InOut)*motorcontrol_config.rated_torque) / 1000; //offset torque received in 1/1000 of rated torque
 
         /* tuning pdos */
         tuning_command = pdo_get_tuning_command(InOut); // mode 3, 2 and 1 in tuning command


### PR DESCRIPTION
Fix qei index type enum to use 2 for two channels (AB) and 3 for three channels (ABI)
Those values are more natural when used in ethercat drive sdo parameters.
I also put the fix of the torque offset unit in ethercat drive (in 1/1000 of rated torque)