### PR TITLE
Fix cia402 state machine

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ sc_sncn_ethercat_drive Change Log
 
   * Fix torque offset pdo unit (now in 1/1000 of rated torque)
   * Fix value of Encoder Number of Channels to 2 for AB and 3 for ABI.
+  * Fix bug in CiA 402 state machine.
 
 
 3.0.2

--- a/module_ethercat_drive/src/ethercat_drive_service.xc
+++ b/module_ethercat_drive/src/ethercat_drive_service.xc
@@ -167,6 +167,9 @@ static int quick_stop_init(int opmode,
     if (actual_velocity < 0) {
         actual_velocity = -actual_velocity;
     }
+    if (quick_stop_deceleration == 0) {
+        quick_stop_deceleration = 1;
+    }
     int steps_limit = (1000*actual_velocity)/quick_stop_deceleration + 1;
     if (steps > steps_limit) {
         steps = steps_limit;
@@ -603,7 +606,7 @@ void ethercat_drive_service(ProfilerConfig &profiler_config,
 //        debug_print_state(state);
 
         if (opmode == OPMODE_NONE) {
-            statusword      = update_statusword(statusword, state, 0, 0, 0); /* FiXME update ack, q_active and shutdown_ack */
+            statusword      = update_statusword(statusword, state, 0, quick_stop_steps, 0); /* FiXME update ack and shutdown_ack */
             /* for safety considerations, if no opmode choosen, the brake should blocking. */
             i_torque_control.set_brake_status(0);
 
@@ -612,7 +615,7 @@ void ethercat_drive_service(ProfilerConfig &profiler_config,
 
         } else if (opmode == OPMODE_CSP || opmode == OPMODE_CST || opmode == OPMODE_CSV) {
             /* FIXME Put this into a separate CSP, CST, CSV function! */
-            statusword      = update_statusword(statusword, state, 0, 0, 0); /* FiXME update ack, q_active and shutdown_ack */
+            statusword      = update_statusword(statusword, state, 0, quick_stop_steps, 0); /* FiXME update ack and shutdown_ack */
 
             /*
              * Additionally used bits in statusword for...
@@ -777,7 +780,7 @@ void ethercat_drive_service(ProfilerConfig &profiler_config,
                 opmode = opmode_request; /* stop tuning and switch to new opmode */
                 i_motion_control.disable();
                 state = S_SWITCH_ON_DISABLED;
-                statusword      = update_statusword(0, state, 0, 0, 0); /* FiXME update ack, q_active and shutdown_ack */
+                statusword      = update_statusword(0, state, 0, quick_stop_steps, 0); /* FiXME update ack and shutdown_ack */
                 //reset tuning status
                 tuning_mode_state.brake_flag = 0;
                 tuning_mode_state.flags = tuning_set_flags(tuning_mode_state, motorcontrol_config, motion_control_config,
@@ -790,7 +793,7 @@ void ethercat_drive_service(ProfilerConfig &profiler_config,
              * For safety reasons, if no opmode is selected the brake is closed! */
             i_torque_control.set_brake_status(0);
             opmode = OPMODE_NONE;
-            statusword      = update_statusword(statusword, state, 0, 0, 0); /* FiXME update ack, q_active and shutdown_ack */
+            statusword      = update_statusword(statusword, state, 0, quick_stop_steps, 0); /* FiXME update ack and shutdown_ack */
         }
 
         /* wait 1 ms to respect timing */

--- a/module_ethercat_drive/src/state_machine.xc
+++ b/module_ethercat_drive/src/state_machine.xc
@@ -200,7 +200,7 @@ int get_next_state(int in_state, check_list &checklist, int controlword, int loc
         case S_NOT_READY_TO_SWITCH_ON:
             if (checklist.fault)
                 out_state = S_FAULT_REACTION_ACTIVE;
-            else // transision 1 auto
+            else // transition 1 auto
                 out_state = S_SWITCH_ON_DISABLED;
             break;
 

--- a/module_ethercat_drive/src/state_machine.xc
+++ b/module_ethercat_drive/src/state_machine.xc
@@ -41,7 +41,8 @@ bool ctrl_shutdown(int control_word) {
 bool ctrl_switch_on(int control_word) {
     return read_controlword_switch_on(control_word)
         && read_controlword_enable_voltage(control_word)
-        && read_controlword_quick_stop(control_word);
+        && read_controlword_quick_stop(control_word)
+        && !read_controlword_enable_op(control_word);
 }
 
 bool ctrl_disable_volt(int control_word) {
@@ -57,19 +58,14 @@ bool ctrl_disable_op(int control_word) {
     return read_controlword_switch_on(control_word)
         && read_controlword_enable_voltage(control_word)
         && read_controlword_quick_stop(control_word)
-        && !read_controlword_enable_voltage(control_word);
+        && !read_controlword_enable_op(control_word);
 }
 
 bool ctrl_enable_op(int control_word) {
     return read_controlword_switch_on(control_word)
         && read_controlword_enable_voltage(control_word)
         && read_controlword_quick_stop(control_word)
-        && read_controlword_enable_voltage(control_word);
-}
-
-bool ctrl_quick_stop_enable(int control) {
-    //return ((control & CTRL_QUICK_STOP_INIT) == 0 ? 0 : 1);
-    return ( ((control&0x0006) == 0x0002) ? true : false );
+        && read_controlword_enable_op(control_word);
 }
 
 bool ctrl_quick_stop_finished(int control) {
@@ -119,6 +115,12 @@ int init_state(void) {
 
 int16_t update_statusword(int current_status, DriveState_t state_reached, int ack, int q_active, int shutdown_ack) {
     int16_t status_word;
+
+    //set quick stop bit to 0 when quick stop active
+    if (q_active == 0)
+        status_word |= (QUICK_STOP_STATE);
+    else
+        status_word &= (~QUICK_STOP_STATE);
 
     /* set/clear the corresponding bits in the statusword using this pattern:
      * status_word = (current_status
@@ -179,9 +181,6 @@ int16_t update_statusword(int current_status, DriveState_t state_reached, int ac
             status_word = current_status;
             break;
     }
-
-    if (q_active == 1)
-        return status_word & (~QUICK_STOP_STATE);
     if (shutdown_ack == 1)
         return status_word & (~VOLTAGE_ENABLED_STATE);
     if (ack == 1)
@@ -195,35 +194,31 @@ int16_t update_statusword(int current_status, DriveState_t state_reached, int ac
 /* localcontrol is used for internal (aka automatic) state transitions */
 int get_next_state(int in_state, check_list &checklist, int controlword, int localcontrol) {
     int out_state = -1;
-    int ctrl_input;
 
     switch(in_state)
     {
         case S_NOT_READY_TO_SWITCH_ON:
             if (checklist.fault)
                 out_state = S_FAULT_REACTION_ACTIVE;
-            else 
+            else // transision 1 auto
                 out_state = S_SWITCH_ON_DISABLED;
             break;
 
         case S_SWITCH_ON_DISABLED:
             if (checklist.fault || ctrl_communication_timeout(localcontrol))
                 out_state = S_FAULT_REACTION_ACTIVE;
-            else if (ctrl_shutdown(controlword)) // aka ready
+            else if (ctrl_shutdown(controlword)) // transition 2
                 out_state = S_READY_TO_SWITCH_ON;
             else
                 out_state = S_SWITCH_ON_DISABLED;
             break;
 
         case S_READY_TO_SWITCH_ON:
-            ctrl_input = read_controlword_switch_on(controlword);
             if (checklist.fault || ctrl_communication_timeout(localcontrol))
                 out_state = S_FAULT_REACTION_ACTIVE;
-            else if (ctrl_switch_on(controlword))
+            else if (ctrl_switch_on(controlword)) // transition 3
                 out_state = S_SWITCH_ON;
-            //else if (ctrl_shutdown(controlword))
-            //    out_state = S_READY_TO_SWITCH_ON;
-            else if ( (ctrl_disable_volt(controlword) || ctrl_quick_stop(controlword) ))
+            else if ( (ctrl_disable_volt(controlword) || ctrl_quick_stop(controlword) )) // transition 7
                 out_state = S_SWITCH_ON_DISABLED;
             else if (ctrl_communication_timeout(controlword))
                 out_state = S_SWITCH_ON_DISABLED;
@@ -232,16 +227,15 @@ int get_next_state(int in_state, check_list &checklist, int controlword, int loc
             break;
 
         case S_SWITCH_ON:
-            ctrl_input = read_controlword_enable_op(controlword);
             if (checklist.fault || ctrl_communication_timeout(localcontrol))
                 out_state = S_FAULT_REACTION_ACTIVE;
-            else if (ctrl_enable_op(controlword))
+            else if (ctrl_enable_op(controlword)) // transition 4
                 out_state = S_OPERATION_ENABLE;
-            else if (ctrl_switch_on(controlword))
+            else if (ctrl_switch_on(controlword)) //stay on the state
                 out_state = S_SWITCH_ON;
-            else if (ctrl_shutdown(controlword))
+            else if (ctrl_shutdown(controlword)) // transition 6
                 out_state = S_READY_TO_SWITCH_ON;
-            else if ( ctrl_disable_volt(controlword) || ctrl_quick_stop(controlword) )
+            else if ( ctrl_disable_volt(controlword) || ctrl_quick_stop(controlword) ) // transition 10
                 out_state = S_SWITCH_ON_DISABLED;
             else if (ctrl_communication_timeout(controlword))
                 out_state = S_SWITCH_ON_DISABLED;
@@ -250,20 +244,19 @@ int get_next_state(int in_state, check_list &checklist, int controlword, int loc
             break;
 
         case S_OPERATION_ENABLE:
-            ctrl_input = read_controlword_quick_stop(controlword); //quick stop
             if (checklist.fault || ctrl_communication_timeout(localcontrol))
                 out_state = S_FAULT_REACTION_ACTIVE;
-            else if (ctrl_disable_op(controlword))
+            else if (ctrl_disable_op(controlword)) // transition 5
                 out_state = S_SWITCH_ON;
-            else if (ctrl_shutdown(controlword))
+            else if (ctrl_shutdown(controlword)) // transition 8
                 out_state = S_READY_TO_SWITCH_ON;
-            else  if ( ctrl_quick_stop(controlword) )
+            else  if ( ctrl_quick_stop(controlword) ) // transition 11
                 out_state = S_QUICK_STOP_ACTIVE;
-            else if ( ctrl_disable_volt(controlword) )
+            else if ( ctrl_disable_volt(controlword) ) // transition 9
                 out_state = S_SWITCH_ON_DISABLED;
-            else if ( ctrl_enable_op(controlword))
+            else if ( ctrl_enable_op(controlword)) //stay on the state
                 out_state = S_OPERATION_ENABLE;
-            else if (ctrl_quick_stop_enable(localcontrol))
+            else if (ctrl_quick_stop(localcontrol)) // transition 11
                 out_state = S_QUICK_STOP_ACTIVE;
             else if (ctrl_communication_timeout(controlword))
                 out_state = S_QUICK_STOP_ACTIVE; /* if we are running, then first do a quick stop */
@@ -274,16 +267,16 @@ int get_next_state(int in_state, check_list &checklist, int controlword, int loc
         case S_QUICK_STOP_ACTIVE:
             if (checklist.fault || ctrl_communication_timeout(localcontrol))
                 out_state = S_FAULT_REACTION_ACTIVE;
-            else if (ctrl_disable_volt(controlword))
+            else if (ctrl_disable_volt(controlword)) // transition 12 (forced)
                 out_state = S_SWITCH_ON_DISABLED; /* FIXME Warning: quick stop has to be finished before switch back to SOD */
-            else if (ctrl_quick_stop_finished(localcontrol))
+            else if (ctrl_quick_stop_finished(localcontrol)) // transition 12 (auto)
                 out_state = S_SWITCH_ON_DISABLED;
             else
                 out_state = S_QUICK_STOP_ACTIVE;
             break;
 
         case S_FAULT_REACTION_ACTIVE:
-            if (ctrl_fault_reaction_finished(localcontrol))
+            if (ctrl_fault_reaction_finished(localcontrol)) // transition 14
                 out_state = S_FAULT;
             else
                 out_state = S_FAULT_REACTION_ACTIVE;
@@ -291,8 +284,7 @@ int get_next_state(int in_state, check_list &checklist, int controlword, int loc
             break;
 
         case S_FAULT:
-            ctrl_input = read_controlword_fault_reset(controlword);
-            if (ctrl_fault_reset(controlword) && checklist.fault_reset_wait == false && !checklist.fault) {
+            if (ctrl_fault_reset(controlword) && checklist.fault_reset_wait == false && !checklist.fault) { // transition 15
                 out_state = S_SWITCH_ON_DISABLED;
             } else {
                 out_state = S_FAULT;


### PR DESCRIPTION
There was a bug in the Enable op controlword reading function which triggered the Switched on -> Op enabled transition.
I checked all the read_controlword functions and the get_next_state function and every transition should be working now.
Also fix division by 0 error in quick stop function.
Also fix a bug in app_master_cyclic debug mode.