### PR TITLE
Hotfix position feedback config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ sc_sncn_ethercat_drive Change Log
   * Fix value of Encoder Number of Channels to 2 for AB and 3 for ABI.
   * Fix bug in CiA 402 state machine.
   * Put error code (0x603F object) into user_miso pdo when not in tuning mode.
+  * Fix bug in position feedback config manager in switching from dual sensor to one sensor.
+  * Bug fixes and improvement in app_master_cyclic.
 
 
 3.0.2

--- a/examples/app_demo_master_cyclic/doc/index.rst
+++ b/examples/app_demo_master_cyclic/doc/index.rst
@@ -53,9 +53,10 @@ Commands
 
 The application provides the following command line arguments
 
-  - ``-h``             print this help and exit
-  - ``-v``             print version and exit
-  - ``-o``             enable sdo upload
+  - ``-h`` print this help and exit
+  - ``-v`` print version and exit
+  - ``-o`` enable sdo upload
+  - ``-d`` enable debug display
   - ``-s <profile velocity>`` velocity in rpm used for CSP
   - ``-a <profile acceleration>`` acceleration in rmp/s used for CSP and CSV
   - ``-t <profile torque acceleration>`` Torque acceleration in 1/1000 of rated torque per second used for CST
@@ -68,6 +69,10 @@ The application is a ``ncurses`` graphical console application. It uses simple c
   - ``[number]``: set target (depends on the opmode)
   - ``r``: reverse target
   - ``s``: disable operation, 'ss' to stop all the slaves
+  - ``d``: enable debug display
+  - ``m``: enable manual mode
+  - ``c[number] | o[number]``: manually set the controlword | opmode
+  - ``a``: acknowledge fault
   - ``q``: quit
 
 The commands are also printed is the app.
@@ -107,7 +112,7 @@ When the application has been compiled, the next step is to run it on the Linux 
 
        > 100
 
-   #. You can stop the selected slave with ``s`` (stop all the slaves with ``ss``). Quit the app with ``q``. And change the selected slave with the ``up`` and ``down`` keyboard arrows (the current selected slave is highlighted).
+   #. You can stop the selected slave with ``s`` (stop all the slaves with ``ss``). Quit the app with ``q``. And change the selected slave with the ``up`` and ``down`` keyboard arrows (the current selected slave is highlighted). If a slave in fault state you need to acknowledge the fault with ``a`` to reset it.
 
 Examine the code
 ++++++++++++++++

--- a/examples/app_demo_master_cyclic/include/cia402.h
+++ b/examples/app_demo_master_cyclic/include/cia402.h
@@ -15,6 +15,24 @@
 #define OPMODE_CSV                   9
 #define OPMODE_CST                   10
 
+#define STATUS_WORD_MASQ_A           0x6f
+#define STATUS_WORD_MASQ_B           0x4f
+
+#define STATUS_NOT_READY             0x00   /* masq B */
+#define STATUS_SWITCH_ON_DISABLED    0x40   /* masq B */
+#define STATUS_READY_SWITCH_ON       0x21
+#define STATUS_SWITCHED_ON           0x23
+#define STATUS_OP_ENABLED            0x27
+#define STATUS_QUICK_STOP            0x07
+#define STATUS_FAULT_REACTION_ACTIVE 0x0f   /* masq B */
+#define STATUS_FAULT                 0x08   /* masq B */
+
+#define CONTROL_BIT_ENABLE_OP        0x08
+#define CONTROL_BIT_QUICK_STOP       0x04
+#define CONTROL_BIT_ENABLE_VOLTAGE   0x02
+#define CONTROL_BIT_SWITCH_ON        0x01
+#define CONTROL_BIT_FAULT_RESET      0x80
+
 typedef enum {
      CIASTATE_NOT_READY = 0
     ,CIASTATE_SWITCH_ON_DISABLED
@@ -36,6 +54,25 @@ typedef enum {
     CIA402_CMD_ENABLE_OPERATION,
     CIA402_CMD_FAULT_RESET,
 } CIA402Command;
+
+#define CIA402_ERROR_CODE_DC_LINK_OVER_VOLTAGE             0x3210
+#define CIA402_ERROR_CODE_DC_LINK_UNDER_VOLTAGE            0x3220
+
+#define CIA402_ERROR_CODE_PHASE_FAILURE_L1                 0x3131
+#define CIA402_ERROR_CODE_PHASE_FAILURE_L2                 0x3132
+#define CIA402_ERROR_CODE_PHASE_FAILURE_L3                 0x3133
+
+#define CIA402_ERROR_CODE_EXCESS_TEMPERATURE_DEVICE        0x4210
+
+#define CIA402_ERROR_CODE_SENSOR                           0x7300
+#define CIA402_ERROR_CODE_MOTOR_COMMUTATION                0x7122
+
+#define CIA402_ERROR_CODE_MOTOR_BLOCKED                    0x7121
+
+/* for all error in this control which could not further specified */
+#define CIA402_ERROR_CODE_CONTROL                          0x8A00
+
+#define CIA402_ERROR_CODE_COMMUNICATION                    0x7500
 
 
 CIA402State cia402_read_state(uint16_t statusword);

--- a/examples/app_demo_master_cyclic/include/operation.h
+++ b/examples/app_demo_master_cyclic/include/operation.h
@@ -27,9 +27,11 @@ typedef struct {
     int last_command;
     int last_value;
     int init;
+    int init_display;
     int select;
     int fault_ack;
     int debug;
+    int manual;
     CIA402State *target_state;
     AppMode app_mode;
 } OutputValues;

--- a/examples/app_demo_master_cyclic/include/utils.h
+++ b/examples/app_demo_master_cyclic/include/utils.h
@@ -16,7 +16,7 @@
 #include <sys/time.h>
 #include <linux/limits.h>
 
-void cmdline(int argc, char **argv, const char *version, int *sdo_enable, int *profile_speed, int *profile_acc, int *profile_torque_acc, char **sdo_config);
+void cmdline(int argc, char **argv, const char *version, int *sdo_enable, int *profile_speed, int *profile_acc, int *profile_torque_acc, char **sdo_config, int *debug);
 
 extern unsigned int sig_alarms;
 extern unsigned int user_alarms;

--- a/examples/app_demo_master_cyclic/src/cia402.c
+++ b/examples/app_demo_master_cyclic/src/cia402.c
@@ -5,25 +5,6 @@
 
 #include "cia402.h"
 
-#define STATUS_WORD_MASQ_A           0x6f
-#define STATUS_WORD_MASQ_B           0x4f
-
-#define STATUS_NOT_READY             0x00   /* masq B */
-#define STATUS_SWITCH_ON_DISABLED    0x40   /* masq B */
-#define STATUS_READY_SWITCH_ON       0x21
-#define STATUS_SWITCHED_ON           0x23
-#define STATUS_OP_ENABLED            0x27
-#define STATUS_QUICK_STOP            0x07
-#define STATUS_FAULT_REACTION_ACTIVE 0x0f   /* masq B */
-#define STATUS_FAULT                 0x08   /* masq B */
-
-#define CONTROL_BIT_ENABLE_OP        0x08
-#define CONTROL_BIT_QUICK_STOP       0x04
-#define CONTROL_BIT_ENABLE_VOLTAGE   0x02
-#define CONTROL_BIT_SWITCH_ON        0x01
-#define CONTROL_BIT_FAULT_RESET      0x80
-
-
 
 CIA402State cia402_read_state(uint16_t statusword)
 {

--- a/examples/app_demo_master_cyclic/src/display.c
+++ b/examples/app_demo_master_cyclic/src/display.c
@@ -102,7 +102,7 @@ void print_help(WINDOW *wnd, int row)
             "s: disable operation, 'ss' to stop all the slaves\n"
             "d: enable debug display\n"
             "m: enable manual mode\n"
-            "c[number] | o[number]: manually set the controlword | opmode\n"
+            "c[dec number] | o[dec number]: manually set the controlword | opmode\n"
             "a: acknowledge fault\n"
             "q: quit"
     );

--- a/examples/app_demo_master_cyclic/src/main.c
+++ b/examples/app_demo_master_cyclic/src/main.c
@@ -25,11 +25,12 @@ int main(int argc, char **argv)
     int profile_speed = 50; //rpm
     int profile_acc = 50; //rpm/s
     int profile_torque_acc = 50; // 1/1000 rated torque / s
+    int debug = 0;
     char *sdo_config_file = malloc(PATH_MAX);
     strncpy(sdo_config_file, default_sdo_config_file, PATH_MAX);
 
     //get parameters from cmdline
-    cmdline(argc, argv, VERSION, &sdo_enable, &profile_speed, &profile_acc, &profile_torque_acc, &sdo_config_file);
+    cmdline(argc, argv, VERSION, &sdo_enable, &profile_speed, &profile_acc, &profile_torque_acc, &sdo_config_file, &debug);
 
     //read sdo parameters from file
     SdoConfigParameter_t sdo_config_parameter;
@@ -86,6 +87,7 @@ int main(int argc, char **argv)
     OutputValues output = {0};
     output.app_mode = CYCLIC_SYNCHRONOUS_MODE;
     output.sign = 1;
+    output.debug = debug;
     output.target_state = malloc(num_slaves*sizeof(CIA402State));
 
 
@@ -97,7 +99,7 @@ int main(int argc, char **argv)
 
         /* Init pdos */
         pdo_output[i].controlword = 0;
-        pdo_output[i].op_mode = 0;
+        pdo_output[i].op_mode = OPMODE_CST;
         pdo_output[i].target_position = 0;
         pdo_output[i].target_torque = 0;
         pdo_output[i].target_velocity = 0;

--- a/examples/app_demo_master_cyclic/src/profile.c
+++ b/examples/app_demo_master_cyclic/src/profile.c
@@ -324,6 +324,10 @@ int init_linear_profile(motion_profile_t *motion_profile)
 {
     motion_profile->s_time = .001f;
 
+    if (motion_profile->qfd == motion_profile->qid) {
+        return 0;
+    }
+
     // compute time needed (in seconds)
     float total_time = (motion_profile->qfd - motion_profile->qid)/motion_profile->acc;
 

--- a/examples/app_demo_master_cyclic/src/utils.c
+++ b/examples/app_demo_master_cyclic/src/utils.c
@@ -28,14 +28,15 @@ static void printhelp(const char *prog)
 {
     printf("Usage: %s [-h] [-v] [-o] [-c <SDO config filename>] [-s <profile velocity>]\n", _basename(prog));
     printf("\n");
-    printf("  -h print this help and exit\n");
-    printf("  -o enable sdo upload\n");
-    printf("  -v print version and exit\n");
-    printf("  -d enable debug display\n");
-    printf("  -s <profile velocity in rpm>\n");
-    printf("  -a <profile acceleration in rpm/s>\n");
-    printf("  -t <profile torque acceleration in 1/1000 of rated torque per second>\n");
-    printf("  -c <SDO config filename>\n");
+    printf("  -h                          print this help and exit\n");
+    printf("  -o                          enable sdo upload\n");
+    printf("  -v                          print version and exit\n");
+    printf("  -d                          enable debug display\n");
+    printf("  -s <speed>                  profile velocity in rpm\n");
+    printf("  -a <acceleration>           profile acceleration in rpm/s\n");
+    printf("  -t <torque acceleration>    profile torque acceleration\n"
+           "                              in 1/1000 of rated torque per second\n");
+    printf("  -c <file>                   SDO config filename\n");
 }
 
 void cmdline(int argc, char **argv, const char *version, int *sdo_enable, int *profile_speed, int *profile_acc, int *profile_torque_acc, char **sdo_config, int *debug)

--- a/examples/app_demo_master_cyclic/src/utils.c
+++ b/examples/app_demo_master_cyclic/src/utils.c
@@ -28,26 +28,31 @@ static void printhelp(const char *prog)
 {
     printf("Usage: %s [-h] [-v] [-o] [-c <SDO config filename>] [-s <profile velocity>]\n", _basename(prog));
     printf("\n");
-    printf("  -h             print this help and exit\n");
-    printf("  -o             enable sdo upload\n");
-    printf("  -v             print version and exit\n");
+    printf("  -h print this help and exit\n");
+    printf("  -o enable sdo upload\n");
+    printf("  -v print version and exit\n");
+    printf("  -d enable debug display\n");
     printf("  -s <profile velocity in rpm>\n");
     printf("  -a <profile acceleration in rpm/s>\n");
     printf("  -t <profile torque acceleration in 1/1000 of rated torque per second>\n");
     printf("  -c <SDO config filename>\n");
 }
 
-void cmdline(int argc, char **argv, const char *version, int *sdo_enable, int *profile_speed, int *profile_acc, int *profile_torque_acc, char **sdo_config)
+void cmdline(int argc, char **argv, const char *version, int *sdo_enable, int *profile_speed, int *profile_acc, int *profile_torque_acc, char **sdo_config, int *debug)
 {
     int  opt;
 
-    const char *options = "hvos:c:a:t:";
+    const char *options = "hvods:c:a:t:";
 
     while ((opt = getopt(argc, argv, options)) != -1) {
         switch (opt) {
         case 'v':
             printversion(argv[0], version);
             exit(0);
+            break;
+
+        case 'd':
+            *debug = 1;
             break;
 
         case 's':

--- a/module_ethercat_drive/src/config_manager.xc
+++ b/module_ethercat_drive/src/config_manager.xc
@@ -81,10 +81,9 @@ int cm_sync_config_position_feedback(
         }
     }
 
+    int old_sensor_type = config.sensor_type; //too check if we need to restart the service
+
     if (feedback_sensor_object != 0) {
-
-        int old_sensor_type = config.sensor_type; //too check if we need to restart the service
-
         config.sensor_type             = i_coe.get_object_value(feedback_sensor_object, 1);
         config.sensor_function         = sensor_function;
         config.resolution              = i_coe.get_object_value(feedback_sensor_object, 3);
@@ -92,11 +91,6 @@ int cm_sync_config_position_feedback(
         config.polarity                = i_coe.get_object_value(feedback_sensor_object, 5);
         config.pole_pairs              = i_coe.get_object_value(DICT_MOTOR_SPECIFIC_SETTINGS, SUB_MOTOR_SPECIFIC_SETTINGS_POLE_PAIRS);
         config.offset                  = i_coe.get_object_value(DICT_HOME_OFFSET, 0);
-
-        //restart the service if the sensor type is changed
-        if (old_sensor_type != config.sensor_type) {
-            restart = 1;
-        }
 
         // sensor specific parameters
         // use port_index to select the port number used for hall, qei or biss
@@ -159,10 +153,18 @@ int cm_sync_config_position_feedback(
                 config.gpio_config[i] = i_coe.get_object_value(DICT_GPIO, i+1);
             }
 
-        i_pos_feedback.set_config(config);
-
         port_index++; //the next port to check
+    } else { //disable service if not set
+        config.sensor_type = 0;
+        config.sensor_function = SENSOR_FUNCTION_DISABLED;
     }
+
+    //restart the service if the sensor type is changed
+    if (old_sensor_type != config.sensor_type) {
+        restart = 1;
+    }
+
+    i_pos_feedback.set_config(config);
 
     return restart;
 }


### PR DESCRIPTION
This fix a bug in the position feedback config manager when switching from a dual sensor to one sensor config the second service was not turned off.
So it was still sending the incorrect position to the shared memory overwriting the good position.

Also bug fixes and improvement in app_master_cyclic:
- fix: the backspace command clear the display but not the values. So if you type 10, backspace, 200 it will send 10200.
- fix: enter without a number in velocity mode sends (- int max) instead of 0
- start in CST opmode so the state machine is working.
- automatically reset the communication timeout error. More serious faults (over current, etc) need to be reset manually.
- add display of error code.
- improve debug mode:  add a manual mode to disable the auto state machine control for debug.