### PR TITLE
Add Cogging torque to the ethercat application

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 sc_sncn_ethercat_drive Change Log
 ==================================
 
+3.1
+---
+
+  * Add cogging torque calibration command
+
 3.0.3
 -----
 

--- a/examples/app_demo_master_ethercat_tuning/doc/index.rst
+++ b/examples/app_demo_master_ethercat_tuning/doc/index.rst
@@ -185,6 +185,8 @@ When the application has been compiled, the next step is to run it on the Linux 
 
    #. Use the commands previously described to find the commutation offset then tune and test the position/velocity/torque controllers. After you found the optimal parameters please note them (don't quit the app!) and update your ``sdo_config.csv`` file. You can also test the CSP,CSV,CST CiA 402 operation modes with the ``app_master_cyclic``.
 
+   #. Once the controllers are tuned, you can test the cogging torque compensation. Use the command 'ac', the motor will start to calibrate, make two turns in each direction and stop. Once the compesator is calibrated, you can enable/disable it with the command ec. Note : to be able to calibrate, you need a good velocity tuning at 10 rpm. 
+   
 Examine the code
 ++++++++++++++++
 

--- a/examples/app_demo_master_ethercat_tuning/doc/index.rst
+++ b/examples/app_demo_master_ethercat_tuning/doc/index.rst
@@ -9,6 +9,7 @@ SOMANET EtherCat Drive Special Tuning Mode Application
 
 This application is demonstrating the use of the tuning mode of SOMANET EtherCat Drive.
 It allows finding the commutation offset of the motor, tuning of the PID parameters and test the Position, Velocity and Torque controllers. 
+The application is given the functionnality to compensate :ref:`the cogging torque <Cogging-Torque-Feature>` of the motor, allowing a better control at low speed.
 
 .. cssclass:: github
 
@@ -78,6 +79,7 @@ The rest of the commands can be up to 3 characters with an optional number. The 
 The number can be negative. Spaces are ignored. The default number value is 0.
 
   - ``a``: start the auto offset tuning. It automatically update the offset field display. If the offset detection fails the offset will be -1. After the offset is found you need to make sure that a positive torque command result in a positive velocity/position increment. Otherwise the position and velocity controller will not work.
+  - ``ac``:  start the cogging torque detection. It automatically records the cogging torque present in the motor in one mechanical rotation. After the torque is recorded, press “ec1” to enable the compensation of the cogging torque
   - ``ap2``: start the automatic tuning of cascaded position controller. while cascaded position controller is being tuned, the dynamic values of PID controllers are shown on the terminal.
   - ``ap3``: start the automatic tuning of limited-torque position controller. During the automatic tuning procedure, the dynamic change of PID constants are updated on the terminal.
   - ``av``: start the automatic tuning of velocity controller. During the automatic tuning procedure, the dynamic change of PID constants are updated on the terminal.

--- a/examples/app_demo_master_ethercat_tuning/include/tuning.h
+++ b/examples/app_demo_master_ethercat_tuning/include/tuning.h
@@ -58,6 +58,7 @@ typedef enum {
     TUNING_CMD_AUTO_POS_CTRL_TUNE         = 0x0B,
     TUNING_CMD_AUTO_VEL_CTRL_TUNE         = 0x0C,
     TUNING_CMD_COGGING_TORQUE             = 0x0D,
+    TUNING_CMD_AUTO_RECORD_COGGING        = 0x0E,
     TUNING_CMD_POSITION_KP                = 0xC0,
     TUNING_CMD_POSITION_KI                = 0xC1,
     TUNING_CMD_POSITION_KD                = 0xC2,

--- a/examples/app_demo_master_ethercat_tuning/src/tuning.c
+++ b/examples/app_demo_master_ethercat_tuning/src/tuning.c
@@ -222,6 +222,9 @@ void tuning_command(WINDOW *wnd, struct _pdo_cia402_output *pdo_output, struct _
                     }
                     pdo_output->user_mosi = output->value;
                     break;
+                case 'c':
+                    pdo_output->tuning_command = TUNING_CMD_AUTO_RECORD_COGGING;
+                    break;
                 case 'v':
                     pdo_output->tuning_command = TUNING_CMD_AUTO_VEL_CTRL_TUNE;
                     pdo_output->target_velocity = 0;

--- a/examples/app_demo_slave_ethercat_motorcontrol/src/main.xc
+++ b/examples/app_demo_slave_ethercat_motorcontrol/src/main.xc
@@ -174,6 +174,7 @@ int main(void)
                     motion_ctrl_config.velocity_kd =                          VELOCITY_Kd;
                     motion_ctrl_config.velocity_integral_limit =              VELOCITY_INTEGRAL_LIMIT;
                     motion_ctrl_config.enable_velocity_auto_tuner =           ENABLE_VELOCITY_AUTO_TUNER;
+                    motion_ctrl_config.enable_compensation_recording =        ENABLE_COMPENSATION_RECORDING;
 
 
                     motion_ctrl_config.brake_release_strategy =               BRAKE_RELEASE_STRATEGY;
@@ -253,6 +254,10 @@ int main(void)
                     motorcontrol_config.protection_limit_under_voltage = PROTECTION_MINIMUM_VOLTAGE;
                     motorcontrol_config.protection_limit_over_temperature = TEMP_BOARD_MAX;
 
+                    for (int i = 0; i < 1024; i++)
+                    {
+                        motorcontrol_config.torque_offset[i] = 0;
+                    }
                     torque_control_service(motorcontrol_config, i_adc[0], i_shared_memory[2],
                             i_watchdog[0], i_torque_control, i_update_pwm, IFM_TILE_USEC);
                 }

--- a/module_network_drive/include/tuning.h
+++ b/module_network_drive/include/tuning.h
@@ -46,6 +46,7 @@ typedef enum {
     TUNING_CMD_AUTO_POS_CTRL_TUNE         = 0x0B,
     TUNING_CMD_AUTO_VEL_CTRL_TUNE         = 0x0C,
     TUNING_CMD_COGGING_TORQUE             = 0x0D,
+    TUNING_CMD_AUTO_RECORD_COGGING        = 0x0E,
     TUNING_CMD_POSITION_KP                = 0xC0,
     TUNING_CMD_POSITION_KI                = 0xC1,
     TUNING_CMD_POSITION_KD                = 0xC2,

--- a/module_network_drive/src/tuning.xc
+++ b/module_network_drive/src/tuning.xc
@@ -458,10 +458,10 @@ void tuning_command_handler(
 
             tuning_mode_state.motorctrl_status = TUNING_MOTORCTRL_VELOCITY;
             i_motion_control.enable_velocity_ctrl();
-            printf("Find cogging torque\n");
             motion_ctrl_config = i_motion_control.get_motion_control_config();
             motion_ctrl_config.enable_compensation_recording = 1;
             i_motion_control.set_motion_control_config(motion_ctrl_config);
+            break;
 
         } /* end switch action command*/
     } /* end if setting/action command */

--- a/module_network_drive/src/tuning.xc
+++ b/module_network_drive/src/tuning.xc
@@ -453,6 +453,16 @@ void tuning_command_handler(
             }
             break;
 
+        // start the recording of the cogging torque
+        case TUNING_CMD_AUTO_RECORD_COGGING:
+
+            tuning_mode_state.motorctrl_status = TUNING_MOTORCTRL_VELOCITY;
+            i_motion_control.enable_velocity_ctrl();
+            printf("Find cogging torque\n");
+            motion_ctrl_config = i_motion_control.get_motion_control_config();
+            motion_ctrl_config.enable_compensation_recording = 1;
+            i_motion_control.set_motion_control_config(motion_ctrl_config);
+
         } /* end switch action command*/
     } /* end if setting/action command */
 }


### PR DESCRIPTION
Add the command 'ac' to start recording the cogging torque from the master and the slave side
Add the initialization at startup of the cogging torque parameters.