### PR TITLE
enable configuration update in switch_on_disabled only once

### DIFF
--- a/module_ethercat_drive/src/ethercat_drive_service.xc
+++ b/module_ethercat_drive/src/ethercat_drive_service.xc
@@ -656,13 +656,18 @@ void ethercat_drive_service(ProfilerConfig &profiler_config,
                 break;
 
             case S_SWITCH_ON_DISABLED:
+            {
                 /* we allow opmode change in this state */
-                //check and update opmode
                 opmode = update_opmode(opmode, opmode_request, i_motion_control, motion_control_config, polarity);
-                read_configuration = 1;
+
+                enum e_States current_state = state;
 
                 /* communication active, idle no motor control; read opmode from PDO and set control accordingly */
                 state = get_next_state(state, checklist, controlword, 0);
+                if (state != current_state)
+                    read_configuration = 1;
+
+            }
                 break;
 
             case S_READY_TO_SWITCH_ON:

--- a/module_ethercat_drive/src/ethercat_drive_service.xc
+++ b/module_ethercat_drive/src/ethercat_drive_service.xc
@@ -378,7 +378,7 @@ void ethercat_drive_service(ProfilerConfig &profiler_config,
 
     unsigned int time;
     enum e_States state     = S_NOT_READY_TO_SWITCH_ON;
-    //enum e_States state_old = state; /* necessary for something??? */
+    enum e_States state_old = state;
 
     uint16_t statusword = update_statusword(0, state, 0, 0, 0);
     int controlword = 0;
@@ -656,18 +656,15 @@ void ethercat_drive_service(ProfilerConfig &profiler_config,
                 break;
 
             case S_SWITCH_ON_DISABLED:
-            {
+
                 /* we allow opmode change in this state */
                 opmode = update_opmode(opmode, opmode_request, i_motion_control, motion_control_config, polarity);
 
-                enum e_States current_state = state;
-
                 /* communication active, idle no motor control; read opmode from PDO and set control accordingly */
                 state = get_next_state(state, checklist, controlword, 0);
-                if (state != current_state)
+                if (state != state_old) {
                     read_configuration = 1;
-
-            }
+                }
                 break;
 
             case S_READY_TO_SWITCH_ON:
@@ -818,6 +815,8 @@ void ethercat_drive_service(ProfilerConfig &profiler_config,
             opmode = OPMODE_NONE;
             statusword      = update_statusword(statusword, state, 0, quick_stop_steps, 0); /* FiXME update ack and shutdown_ack */
         }
+
+        state_old = state;
 
         /* wait 1 ms to respect timing */
         t when timerafter(time + tile_usec*1000) :> time;

--- a/module_ethercat_drive/src/ethercat_drive_service.xc
+++ b/module_ethercat_drive/src/ethercat_drive_service.xc
@@ -656,15 +656,11 @@ void ethercat_drive_service(ProfilerConfig &profiler_config,
                 break;
 
             case S_SWITCH_ON_DISABLED:
-
                 /* we allow opmode change in this state */
                 opmode = update_opmode(opmode, opmode_request, i_motion_control, motion_control_config, polarity);
 
                 /* communication active, idle no motor control; read opmode from PDO and set control accordingly */
                 state = get_next_state(state, checklist, controlword, 0);
-                if (state != state_old) {
-                    read_configuration = 1;
-                }
                 break;
 
             case S_READY_TO_SWITCH_ON:
@@ -816,6 +812,10 @@ void ethercat_drive_service(ProfilerConfig &profiler_config,
             statusword      = update_statusword(statusword, state, 0, quick_stop_steps, 0); /* FiXME update ack and shutdown_ack */
         }
 
+        /* update config when entering the S_SWITCH_ON_DISABLED state */
+        if (state == S_SWITCH_ON_DISABLED && state_old != S_SWITCH_ON_DISABLED) {
+            read_configuration = 1;
+        }
         state_old = state;
 
         /* wait 1 ms to respect timing */


### PR DESCRIPTION
This commit fixes a bug with a slow down of PDO communication due to overhead with parameters update in switch-on-disabled state. 