### PR TITLE
Feature float pid

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 sc_sncn_ethercat_drive Change Log
 ==================================
 
+3.1.1
+-----
+
+  * Fix data type of PID coefficients to use float.
+
 3.1
 ---
 

--- a/examples/app_demo_master_cyclic/Makefile
+++ b/examples/app_demo_master_cyclic/Makefile
@@ -10,12 +10,12 @@ INCLUDE += -Isdo_config
 LIB_PATH = -L/opt/etherlab/lib
 LIB_PATH += -L../libreadsdoconfig/lib
 
-LIBRARY =  -lethercat_wrapper -lethercat -lm -lreadsdoconfig
+LIBRARY =  -lethercat_wrapper -lethercat -lreadsdoconfig
 
 CFLAGS += $(FLAGS)
 CFLAGS += -Wall --std=c99 -g -O2 $(INCLUDE) -D_XOPEN_SOURCE
 LDFLAGS = -g -Wall -Wextra $(LIB_PATH) $(LIBRARY)
-LIBS_D += -g -Wall -Wextra -lncurses
+LIBS_D += -g -Wall -Wextra -lncurses -lm
 
 TARGET = bin/app_demo_master_cyclic
 

--- a/examples/app_demo_master_ethercat_tuning/Makefile
+++ b/examples/app_demo_master_ethercat_tuning/Makefile
@@ -12,12 +12,12 @@ INCLUDE += -Isdo_config
 LIB_PATH = -L/opt/etherlab/lib
 LIB_PATH += -L../libreadsdoconfig/lib
 
-LIBRARY =  -lethercat_wrapper -lethercat -lm -lreadsdoconfig
+LIBRARY =  -lethercat_wrapper -lethercat -lreadsdoconfig
 
 CFLAGS += $(FLAGS)
 CFLAGS += -Wall --std=c99 -g -O2 $(INCLUDE) -D_XOPEN_SOURCE
 LDFLAGS = -g -Wall -Wextra $(LIB_PATH) $(LIBRARY)
-LIBS_D += -g -Wall -Wextra -lncurses
+LIBS_D += -g -Wall -Wextra -lncurses -lm
 
 TARGET = bin/app_demo_master_ethercat_tuning
 

--- a/examples/app_demo_master_ethercat_tuning/src/ecat_sdo_config.c
+++ b/examples/app_demo_master_ethercat_tuning/src/ecat_sdo_config.c
@@ -15,12 +15,25 @@
 
 int write_sdo(Ethercat_Slave_t *slave, SdoParam_t *conf)
 {
-    int ret = ecw_slave_set_sdo_value(slave, conf->index, conf->subindex, conf->value);
-    if (ret < 0) {
-        fprintf(stderr, "Error Slave %d, could not download object 0x%04x:%d, value: %d\n",
-                ecw_slave_get_slaveid(slave), conf->index, conf->subindex, conf->value);
-        return -1;
+    Sdo_t *sdo = ecw_slave_get_sdo(slave, conf->index, conf->subindex);
+
+    if (sdo->entry_type == 8) { // 8 is REAL32 type
+        int ret = ecw_slave_set_sdo_value(slave, conf->index, conf->subindex, conf->value.real.i);
+        if (ret < 0) {
+            fprintf(stderr, "Error Slave %d, could not download object 0x%04x:%d, value: %f\n",
+                    ecw_slave_get_slaveid(slave), conf->index, conf->subindex, conf->value.real.f);
+            return -1;
+        }
+    } else {
+        int ret = ecw_slave_set_sdo_value(slave, conf->index, conf->subindex, conf->value.integer);
+        if (ret < 0) {
+            fprintf(stderr, "Error Slave %d, could not download object 0x%04x:%d, value: %d\n",
+                    ecw_slave_get_slaveid(slave), conf->index, conf->subindex, conf->value.integer);
+            return -1;
+        }
     }
+
+    free(sdo);
 
     return 0;
 }
@@ -50,7 +63,7 @@ int read_sdo(int slave_number, SdoParam_t **config, size_t max_objects, int inde
 {
     for (int i=0 ; i<max_objects; i++) {
         if (config[slave_number][i].index == index && config[slave_number][i].subindex == subindex) {
-            return config[slave_number][i].value;
+            return config[slave_number][i].value.integer;
         }
     }
     return 0;

--- a/examples/libreadsdoconfig/Makefile
+++ b/examples/libreadsdoconfig/Makefile
@@ -5,7 +5,7 @@ AR = ar
 WARNING = -Wall -Wextra
 OPTIMIZIE = 2
 CFLAGS = $(WARNING) -O$(OPTIMIZE) --std=c99 -g -Iinclude
-LDFLAGS = $(WARNING)
+LDFLAGS = $(WARNING) -lm
 ARFLAGS = rcs
 
 TARGETPATH = lib

--- a/examples/libreadsdoconfig/Makefile
+++ b/examples/libreadsdoconfig/Makefile
@@ -5,7 +5,7 @@ AR = ar
 WARNING = -Wall -Wextra
 OPTIMIZIE = 2
 CFLAGS = $(WARNING) -O$(OPTIMIZE) --std=c99 -g -Iinclude
-LDFLAGS = $(WARNING) -lm
+LDFLAGS = $(WARNING)
 ARFLAGS = rcs
 
 TARGETPATH = lib

--- a/examples/libreadsdoconfig/include/readsdoconfig.h
+++ b/examples/libreadsdoconfig/include/readsdoconfig.h
@@ -14,13 +14,24 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+union Data {
+   uint32_t i;
+   float    f;
+};
+
+typedef struct {
+  uint32_t   integer;
+  union Data real;
+} Value_t;
+  
+
 /**
  * \brief Structure describing a individual parameter
  */
 typedef struct {
   uint16_t index;      ///< Index of the associated object in the object dictionary
   uint8_t  subindex;   ///< Subindex of this object
-  uint32_t value;      ///< Value of the container /* FIXME hold values of arbitrary size! */
+  Value_t  value;      ///< Value of the container /* FIXME hold values of arbitrary size! */
   size_t   bytecount;  /* for this value I need access to the object dictionary! FIXME may remove from here! */
 } SdoParam_t;
 

--- a/examples/libreadsdoconfig/src/main.c
+++ b/examples/libreadsdoconfig/src/main.c
@@ -53,8 +53,9 @@ int main(int argc, char *argv[])
     for (size_t k = 0; k < config_parameter.param_count; k++) {
       SdoParam_t *p = nparam + k;
 
-      printf("N%zu: 0x%04x:%d = %d\n",
-             i, p->index, p->subindex, p->value);
+      printf("N%zu: 0x%04x:%d = %d (%f)\n",
+             i, p->index, p->subindex,
+             p->value.integer, p->value.real.f);
     }
   }
 

--- a/examples/libreadsdoconfig/src/readsdoconfig.c
+++ b/examples/libreadsdoconfig/src/readsdoconfig.c
@@ -13,7 +13,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
-#include <math.h>
 
 #define MAX_INPUT_LINE    1024
 #define MAX_TOKEN_SIZE    255
@@ -95,12 +94,8 @@ static Value_t parse_token(char *token_str)
   value.integer = (uint32_t)strtol(token_str, &str_end, 0);
   
   if (*str_end == '.' && isdigit(*(str_end+1))) {
-    //we found a dot, parse as float value
-    char *str_end2 = NULL;
-    long frac = strtol(str_end+1, &str_end2, 0);
-    // value real = value before the dot + value after the dot / number of digits after the dot
-    // (str_end2-str_end-1) is the number of digits after the dot
-    value.real.f = (float)((double)value.integer + ((double)frac)/pow(10, str_end2-str_end-1));
+    // we found a dot, parse as float value
+    sscanf(token_str, "%f", &(value.real.f));
   } else {
     // if value is an integer save the corresponding float in value.real
     value.real.f = (float)value.integer;

--- a/module_network_drive/include/config_manager.h
+++ b/module_network_drive/include/config_manager.h
@@ -22,6 +22,19 @@ enum eProfileType {
     ,PROFILE_TYPE_VELOCITY
 };
 
+
+/* @brief Type for SDO value
+ *
+ *        The value is transfered as a 32 bit number over ethercat
+ *        but it can contain ether an int or a float.
+ *        This union allows to receive the value in an int and then
+ *        interpret it as float.
+ */
+union sdo_value {
+   int i;
+   float f;
+};
+
 /*
  * General, syncronize configuration with the object dictionary values provided
  * by the master.

--- a/module_network_drive/include/statemachine.h
+++ b/module_network_drive/include/statemachine.h
@@ -105,13 +105,15 @@ int get_next_state(int in_state, check_list &checklist, int controlword, int loc
  * @param i_motion_control client interface to the motion control
  * @param motion_control_config config of to the motion control
  * @param polarity CiA402 object 0x607E DICT_POLARITY
+ * @param read_configuration to update configuration when switching to tuning mode
  *
  * @return new opmode, OPMODE_NONE if opmode is unsupported
  */
 int8_t update_opmode(int8_t opmode, int8_t opmode_request,
         client interface MotionControlInterface i_motion_control,
         MotionControlConfig &motion_control_config,
-        uint8_t polarity);
+        uint8_t polarity,
+        int &read_configuration);
 
 int read_controlword_switch_on(int control_word);
 

--- a/module_network_drive/src/config_manager.xc
+++ b/module_network_drive/src/config_manager.xc
@@ -190,11 +190,17 @@ int cm_sync_config_motor_control(
 
     motorcontrol_config = i_torque_control.get_config();
 
+    //convert float values
+    union sdo_value temp;
+    {temp.i, void, void} = i_co.od_get_object_value(DICT_TORQUE_CONTROLLER, SUB_TORQUE_CONTROLLER_CONTROLLER_KP);
+    motorcontrol_config.torque_P_gain = (int)temp.f;
+    {temp.i, void, void} = i_co.od_get_object_value(DICT_TORQUE_CONTROLLER, SUB_TORQUE_CONTROLLER_CONTROLLER_KI);
+    motorcontrol_config.torque_I_gain = (int)temp.f;
+    {temp.i, void, void} = i_co.od_get_object_value(DICT_TORQUE_CONTROLLER, SUB_TORQUE_CONTROLLER_CONTROLLER_KD);
+    motorcontrol_config.torque_D_gain = (int)temp.f;
+
     {motorcontrol_config.dc_bus_voltage, void, void} = i_co.od_get_object_value(DICT_BREAK_RELEASE, SUB_BREAK_RELEASE_DC_BUS_VOLTAGE);
     {motorcontrol_config.phases_inverted, void, void} = i_co.od_get_object_value(DICT_MOTOR_SPECIFIC_SETTINGS, SUB_MOTOR_SPECIFIC_SETTINGS_MOTOR_PHASES_INVERTED);
-    {motorcontrol_config.torque_P_gain, void, void} = i_co.od_get_object_value(DICT_TORQUE_CONTROLLER, SUB_TORQUE_CONTROLLER_CONTROLLER_KP);
-    {motorcontrol_config.torque_I_gain, void, void} = i_co.od_get_object_value(DICT_TORQUE_CONTROLLER, SUB_TORQUE_CONTROLLER_CONTROLLER_KI);
-    {motorcontrol_config.torque_D_gain, void, void} = i_co.od_get_object_value(DICT_TORQUE_CONTROLLER, SUB_TORQUE_CONTROLLER_CONTROLLER_KD);
     {motorcontrol_config.pole_pairs, void, void} = i_co.od_get_object_value(DICT_MOTOR_SPECIFIC_SETTINGS, SUB_MOTOR_SPECIFIC_SETTINGS_POLE_PAIRS);
     motorcontrol_config.commutation_sensor       = sensor_commutation_type;
     {motorcontrol_config.commutation_angle_offset, void, void} = i_co.od_get_object_value(DICT_COMMUTATION_ANGLE_OFFSET, 0);
@@ -259,16 +265,24 @@ void cm_sync_config_pos_velocity_control(
 
     {position_config.position_control_strategy, void, void} = i_co.od_get_object_value(DICT_POSITION_CONTROL_STRATEGY, 0);
 
-    {position_config.position_kp, void, void} = i_co.od_get_object_value(DICT_POSITION_CONTROLLER, SUB_POSITION_CONTROLLER_CONTROLLER_KP);
-    {position_config.position_ki, void, void} = i_co.od_get_object_value(DICT_POSITION_CONTROLLER, SUB_POSITION_CONTROLLER_CONTROLLER_KI);
-    {position_config.position_kd, void, void} = i_co.od_get_object_value(DICT_POSITION_CONTROLLER, SUB_POSITION_CONTROLLER_CONTROLLER_KD);
     {position_config.position_integral_limit, void, void} = i_co.od_get_object_value(DICT_POSITION_CONTROLLER, SUB_POSITION_CONTROLLER_POSITION_INTEGRAL_LIMIT);
+    {position_config.velocity_integral_limit, void, void} = i_co.od_get_object_value(DICT_VELOCITY_CONTROLLER, SUB_VELOCITY_CONTROLLER_CONTROLLER_INTEGRAL_LIMIT);
     {position_config.moment_of_inertia, void, void} = i_co.od_get_object_value(DICT_MOMENT_OF_INERTIA, 0);
 
-    {position_config.velocity_kp, void, void} = i_co.od_get_object_value(DICT_VELOCITY_CONTROLLER, SUB_VELOCITY_CONTROLLER_CONTROLLER_KP);
-    {position_config.velocity_ki, void, void} = i_co.od_get_object_value(DICT_VELOCITY_CONTROLLER, SUB_VELOCITY_CONTROLLER_CONTROLLER_KI);
-    {position_config.velocity_kd, void, void} = i_co.od_get_object_value(DICT_VELOCITY_CONTROLLER, SUB_VELOCITY_CONTROLLER_CONTROLLER_KD);
-    {position_config.velocity_integral_limit, void, void} = i_co.od_get_object_value(DICT_VELOCITY_CONTROLLER, SUB_VELOCITY_CONTROLLER_CONTROLLER_INTEGRAL_LIMIT);
+    // convert float values
+    union sdo_value temp;
+    {temp.i, void, void}        = i_co.od_get_object_value(DICT_POSITION_CONTROLLER, SUB_POSITION_CONTROLLER_CONTROLLER_KP);
+    position_config.position_kp = (int)temp.f;
+    {temp.i, void, void}        = i_co.od_get_object_value(DICT_POSITION_CONTROLLER, SUB_POSITION_CONTROLLER_CONTROLLER_KI);
+    position_config.position_ki = (int)temp.f;
+    {temp.i, void, void}        = i_co.od_get_object_value(DICT_POSITION_CONTROLLER, SUB_POSITION_CONTROLLER_CONTROLLER_KD);
+    position_config.position_kd = (int)temp.f;
+    {temp.i, void, void}        = i_co.od_get_object_value(DICT_VELOCITY_CONTROLLER, SUB_VELOCITY_CONTROLLER_CONTROLLER_KP);
+    position_config.velocity_kp = (int)temp.f;
+    {temp.i, void, void}        = i_co.od_get_object_value(DICT_VELOCITY_CONTROLLER, SUB_VELOCITY_CONTROLLER_CONTROLLER_KI);
+    position_config.velocity_ki = (int)temp.f;
+    {temp.i, void, void}        = i_co.od_get_object_value(DICT_VELOCITY_CONTROLLER, SUB_VELOCITY_CONTROLLER_CONTROLLER_KD);
+    position_config.velocity_kd = (int)temp.f;
 
     /* Brake control settings */
     {position_config.brake_release_strategy, void, void} = i_co.od_get_object_value(DICT_BREAK_RELEASE, SUB_BREAK_RELEASE_BRAKE_RELEASE_STRATEGY);
@@ -412,11 +426,17 @@ void cm_default_config_motor_control(
 
     motorcontrol_config = i_torque_control.get_config();
 
+    //convert float values
+    union sdo_value value;
+    value.f = (float)motorcontrol_config.torque_P_gain;
+    i_co.od_set_object_value(DICT_TORQUE_CONTROLLER, SUB_TORQUE_CONTROLLER_CONTROLLER_KP, value.i);
+    value.f = (float)motorcontrol_config.torque_I_gain;
+    i_co.od_set_object_value(DICT_TORQUE_CONTROLLER, SUB_TORQUE_CONTROLLER_CONTROLLER_KI, value.i);
+    value.f = (float)motorcontrol_config.torque_D_gain;
+    i_co.od_set_object_value(DICT_TORQUE_CONTROLLER, SUB_TORQUE_CONTROLLER_CONTROLLER_KD, value.i);
+
     i_co.od_set_object_value(DICT_BREAK_RELEASE, SUB_BREAK_RELEASE_DC_BUS_VOLTAGE, motorcontrol_config.dc_bus_voltage);
     i_co.od_set_object_value(DICT_MOTOR_SPECIFIC_SETTINGS, SUB_MOTOR_SPECIFIC_SETTINGS_MOTOR_PHASES_INVERTED, motorcontrol_config.phases_inverted);
-    i_co.od_set_object_value(DICT_TORQUE_CONTROLLER, SUB_TORQUE_CONTROLLER_CONTROLLER_KP, motorcontrol_config.torque_P_gain);
-    i_co.od_set_object_value(DICT_TORQUE_CONTROLLER, SUB_TORQUE_CONTROLLER_CONTROLLER_KI, motorcontrol_config.torque_I_gain);
-    i_co.od_set_object_value(DICT_TORQUE_CONTROLLER, SUB_TORQUE_CONTROLLER_CONTROLLER_KD, motorcontrol_config.torque_D_gain);
     i_co.od_set_object_value(DICT_MOTOR_SPECIFIC_SETTINGS, SUB_MOTOR_SPECIFIC_SETTINGS_POLE_PAIRS, motorcontrol_config.pole_pairs);
     i_co.od_set_object_value(DICT_COMMUTATION_ANGLE_OFFSET, 0, motorcontrol_config.commutation_angle_offset);
     i_co.od_set_object_value(DICT_MOTOR_SPECIFIC_SETTINGS, SUB_MOTOR_SPECIFIC_SETTINGS_PHASE_RESISTANCE, motorcontrol_config.phase_resistance);
@@ -471,18 +491,26 @@ void cm_default_config_pos_velocity_control(
 
     i_co.od_set_object_value(DICT_FILTER_COEFFICIENTS, SUB_FILTER_COEFFICIENTS_POSITION_FILTER_COEFFICIENT, position_config.filter);
 
-    //position PID
-    i_co.od_set_object_value(DICT_POSITION_CONTROLLER, SUB_POSITION_CONTROLLER_CONTROLLER_KP, position_config.position_kp);
-    i_co.od_set_object_value(DICT_POSITION_CONTROLLER, SUB_POSITION_CONTROLLER_CONTROLLER_KI, position_config.position_ki);
-    i_co.od_set_object_value(DICT_POSITION_CONTROLLER, SUB_POSITION_CONTROLLER_CONTROLLER_KD, position_config.position_kd);
     i_co.od_set_object_value(DICT_POSITION_CONTROLLER, SUB_POSITION_CONTROLLER_POSITION_INTEGRAL_LIMIT, position_config.position_integral_limit);
+    i_co.od_set_object_value(DICT_VELOCITY_CONTROLLER, SUB_VELOCITY_CONTROLLER_CONTROLLER_INTEGRAL_LIMIT, position_config.velocity_integral_limit);
     i_co.od_set_object_value(DICT_MOMENT_OF_INERTIA, 0, position_config.moment_of_inertia);
 
+    //convert float values
+    union sdo_value value;
+    //position PID
+    value.f = (float)position_config.position_kp;
+    i_co.od_set_object_value(DICT_POSITION_CONTROLLER, SUB_POSITION_CONTROLLER_CONTROLLER_KP, value.i);
+    value.f = (float)position_config.position_ki;
+    i_co.od_set_object_value(DICT_POSITION_CONTROLLER, SUB_POSITION_CONTROLLER_CONTROLLER_KI, value.i);
+    value.f = (float)position_config.position_kd;
+    i_co.od_set_object_value(DICT_POSITION_CONTROLLER, SUB_POSITION_CONTROLLER_CONTROLLER_KD, value.i);
     //velocity PID
-    i_co.od_set_object_value(DICT_VELOCITY_CONTROLLER, SUB_VELOCITY_CONTROLLER_CONTROLLER_KP, position_config.velocity_kp);
-    i_co.od_set_object_value(DICT_VELOCITY_CONTROLLER, SUB_VELOCITY_CONTROLLER_CONTROLLER_KI, position_config.velocity_ki);
-    i_co.od_set_object_value(DICT_VELOCITY_CONTROLLER, SUB_VELOCITY_CONTROLLER_CONTROLLER_KD, position_config.velocity_kd);
-    i_co.od_set_object_value(DICT_VELOCITY_CONTROLLER, SUB_VELOCITY_CONTROLLER_CONTROLLER_INTEGRAL_LIMIT, position_config.velocity_integral_limit);
+    value.f = (float)position_config.velocity_kp;
+    i_co.od_set_object_value(DICT_VELOCITY_CONTROLLER, SUB_VELOCITY_CONTROLLER_CONTROLLER_KP, value.i);
+    value.f = (float)position_config.velocity_ki;
+    i_co.od_set_object_value(DICT_VELOCITY_CONTROLLER, SUB_VELOCITY_CONTROLLER_CONTROLLER_KI, value.i);
+    value.f = (float)position_config.velocity_kd;
+    i_co.od_set_object_value(DICT_VELOCITY_CONTROLLER, SUB_VELOCITY_CONTROLLER_CONTROLLER_KD, value.i);
 
     /* Brake control settings */
     i_co.od_set_object_value(DICT_BREAK_RELEASE, SUB_BREAK_RELEASE_BRAKE_RELEASE_STRATEGY, position_config.brake_release_strategy);

--- a/module_network_drive/src/network_drive_service.xc
+++ b/module_network_drive/src/network_drive_service.xc
@@ -199,10 +199,10 @@ static int check_for_pid_updatate(
         return 0;
     }
 
-    uint32_t value = 0;
+    union sdo_value value;
     uint8_t od_err = 0;
 
-    {value, void, od_err} = i_co.od_get_object_value(changed_index, changed_subindex);
+    {value.i, void, od_err} = i_co.od_get_object_value(changed_index, changed_subindex);
     if (od_err != 0) {
         return 0;
     }
@@ -211,39 +211,39 @@ static int check_for_pid_updatate(
     position_config = i_motion_control.get_motion_control_config();
     if (changed_index    == DICT_FILTER_COEFFICIENTS &&
         changed_subindex == SUB_FILTER_COEFFICIENTS_POSITION_FILTER_COEFFICIENT) {
-        position_config.filter = value;
+        position_config.filter = value.i;
         changed = 1;
     } else if (changed_index    == DICT_POSITION_CONTROLLER &&
                changed_subindex == SUB_POSITION_CONTROLLER_CONTROLLER_KP) {
-        position_config.position_kp = value;
+        position_config.position_kp = (int)value.f;
         changed = 1;
     } else if (changed_index    == DICT_POSITION_CONTROLLER &&
                changed_subindex == SUB_POSITION_CONTROLLER_CONTROLLER_KI) {
-        position_config.position_ki = value;
+        position_config.position_ki = (int)value.f;
         changed = 1;
     } else if (changed_index    == DICT_POSITION_CONTROLLER &&
                changed_subindex == SUB_POSITION_CONTROLLER_CONTROLLER_KD) {
-        position_config.position_kd = value;
+        position_config.position_kd = (int)value.f;
         changed = 1;
     } else if (changed_index    == DICT_POSITION_CONTROLLER &&
                changed_subindex == SUB_POSITION_CONTROLLER_POSITION_INTEGRAL_LIMIT) {
-        position_config.position_integral_limit = value;
+        position_config.position_integral_limit = value.i;
         changed = 1;
     } else if (changed_index    == DICT_VELOCITY_CONTROLLER &&
                changed_subindex == SUB_VELOCITY_CONTROLLER_CONTROLLER_KP) {
-        position_config.velocity_kp = value;
+        position_config.velocity_kp = (int)value.f;
         changed = 1;
     } else if (changed_index    == DICT_VELOCITY_CONTROLLER &&
                changed_subindex == SUB_VELOCITY_CONTROLLER_CONTROLLER_KI) {
-        position_config.velocity_ki = value;
+        position_config.velocity_ki = (int)value.f;
         changed = 1;
     } else if (changed_index    == DICT_VELOCITY_CONTROLLER &&
                changed_subindex == SUB_VELOCITY_CONTROLLER_CONTROLLER_KD) {
-        position_config.velocity_kd = value;
+        position_config.velocity_kd = (int)value.f;
         changed = 1;
     } else if (changed_index    == DICT_VELOCITY_CONTROLLER &&
                changed_subindex == SUB_VELOCITY_CONTROLLER_CONTROLLER_INTEGRAL_LIMIT) {
-        position_config.velocity_integral_limit = value;
+        position_config.velocity_integral_limit = value.i;
         changed = 1;
     }
 

--- a/module_network_drive/src/network_drive_service.xc
+++ b/module_network_drive/src/network_drive_service.xc
@@ -419,6 +419,7 @@ static void motioncontrol_enable(int opmode, int position_control_strategy,
 
 }
 
+#ifdef NETWORK_DRIVE_DEBUG_PRINT_STATE
 static void debug_print_state(DriveState_t state)
 {
     static DriveState_t oldstate = 0;
@@ -458,6 +459,7 @@ static void debug_print_state(DriveState_t state)
 
     oldstate = state;
 }
+#endif
 
 //#pragma xta command "analyze loop ecatloop"
 //#pragma xta command "set required - 1.0 ms"
@@ -512,8 +514,6 @@ void network_drive_service(ProfilerConfig &profiler_config,
     int sensor_commutation = 1;     //sensor service used for commutation (1 or 2)
     int sensor_motion_control = 1;  //sensor service used for motion control (1 or 2)
 
-    int sensor_select = 1;
-
     int communication_active = 0;
     unsigned int c_time;
     int comm_inactive_flag = 0;
@@ -527,7 +527,6 @@ void network_drive_service(ProfilerConfig &profiler_config,
 
     unsigned int time;
     enum e_States state     = S_NOT_READY_TO_SWITCH_ON;
-    //enum e_States state_old = state; /* necessary for something??? */
 
     uint16_t statusword = update_statusword(0, state, 0, 0, 0);
     int controlword = 0;
@@ -775,7 +774,9 @@ void network_drive_service(ProfilerConfig &profiler_config,
         /*
          * new, perform actions according to state
          */
-//        debug_print_state(state);
+#ifdef NETWORK_DRIVE_DEBUG_PRINT_STATE
+        debug_print_state(state);
+#endif
 
         if (opmode == OPMODE_NONE) {
             statusword      = update_statusword(statusword, state, 0, quick_stop_steps, 0); /* FiXME update ack and shutdown_ack */
@@ -783,7 +784,7 @@ void network_drive_service(ProfilerConfig &profiler_config,
             i_torque_control.set_brake_status(0);
 
             //check and update opmode
-            opmode = update_opmode(opmode, opmode_request, i_motion_control, motion_control_config, polarity);
+            opmode = update_opmode(opmode, opmode_request, i_motion_control, motion_control_config, polarity, read_configuration);
 
         } else if (opmode == OPMODE_CSP || opmode == OPMODE_CST || opmode == OPMODE_CSV) {
             /* FIXME Put this into a separate CSP, CST, CSV function! */
@@ -815,11 +816,15 @@ void network_drive_service(ProfilerConfig &profiler_config,
             case S_SWITCH_ON_DISABLED:
                 /* we allow opmode change in this state */
                 //check and update opmode
-                opmode = update_opmode(opmode, opmode_request, i_motion_control, motion_control_config, polarity);
-                read_configuration = 1;
+                opmode = update_opmode(opmode, opmode_request, i_motion_control, motion_control_config, polarity, read_configuration);
 
                 /* communication active, idle no motor control; read opmode from PDO and set control accordingly */
                 state = get_next_state(state, checklist, controlword, 0);
+
+                /* update config on the S_SWITCH_ON_DISABLED -> S_READY_TO_SWITCH_ON transition */
+                if (state == S_READY_TO_SWITCH_ON) {
+                    read_configuration = 1;
+                }
                 break;
 
             case S_READY_TO_SWITCH_ON:
@@ -952,7 +957,7 @@ void network_drive_service(ProfilerConfig &profiler_config,
                     i_motion_control, i_position_feedback_1, i_position_feedback_2);
 
             //check and update opmode
-            opmode = update_opmode(opmode, opmode_request, i_motion_control, motion_control_config, polarity);
+            opmode = update_opmode(opmode, opmode_request, i_motion_control, motion_control_config, polarity, read_configuration);
 
             //exit tuning mode
             if (opmode != OPMODE_SNCN_TUNING) {

--- a/module_network_drive/src/state_machine.xc
+++ b/module_network_drive/src/state_machine.xc
@@ -298,7 +298,8 @@ int get_next_state(int in_state, check_list &checklist, int controlword, int loc
 int8_t update_opmode(int8_t opmode, int8_t opmode_request,
         client interface MotionControlInterface i_motion_control,
         MotionControlConfig &motion_control_config,
-        uint8_t polarity)
+        uint8_t polarity,
+        int &read_configuration)
 {
     if (opmode != opmode_request) {
         motion_control_config = i_motion_control.get_motion_control_config();
@@ -306,7 +307,9 @@ int8_t update_opmode(int8_t opmode, int8_t opmode_request,
         switch(opmode_request) {
         case OPMODE_NONE:
         case OPMODE_CST:
+            break;
         case OPMODE_SNCN_TUNING:
+            read_configuration = 1;
             break;
         //for CSP and CSV we also check the polarity object DICT_POLARITY (0x607E)
         case OPMODE_CSP:


### PR DESCRIPTION
Use float for PID coefficients SDO parameters.
    
- This means the master has to send the value formatted as a float otherwise it will not be interpreted correctly.
- The local PID coefficients are still in integer so they are cast from float in the config manager.
- The csv config parser now support float parsing (using the '.' character).
- The sdo write function is app_master_cyclic and tuning will read the SDO type and send the value as float or integer accordingly.

Also the update config condition is changed. Before, it was updating every loop in the SOD state. Now it will update:
- on S_SWITCH_ON_DISABLED -> S_READY_TO_SWITCH_ON transition
- when switching to tuning mode

And, is this a feature for 3.1 or after?
I didn't update the changelog yet.