### PR TITLE
Fix number of subitems for objects 0x2202

### DIFF
--- a/device_configuration/SOMANET_CiA_402.xml
+++ b/device_configuration/SOMANET_CiA_402.xml
@@ -3816,7 +3816,7 @@
                   <SubItem>
                     <Name>BISS Encoder 2</Name>
                     <Info>
-                      <DefaultData>0C</DefaultData>
+                      <DefaultData>0D</DefaultData>
                     </Info>
                   </SubItem>
                   <SubItem>


### PR DESCRIPTION
The online dictionary has the correct value but in the ESI this entry
was wrong.

Also added the newline at the end of the file, my editor does this
automatically.