### PR TITLE
Fix reloading the configuration from the object dictionary.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ sc_sncn_ethercat_drive Change Log
 -----
 
   * Fix data type of PID coefficients to use float.
+  * Fix reload configuration from object dictionary
 
 3.1
 ---

--- a/module_network_drive/include/cia402_error_codes.h
+++ b/module_network_drive/include/cia402_error_codes.h
@@ -25,7 +25,6 @@
 #define ERROR_CODE_INCREMENTAL_SENSOR_1_FAULT       0x7305
 #define ERROR_CODE_SPEED                            0x7310
 #define ERROR_CODE_POSITION                         0x7320
-#define ERROR_CODE_MOTOR_COMMUTATION                0x7122
 
 #define ERROR_CODE_MOTOR_BLOCKED                    0x7121
 

--- a/module_network_drive/src/network_drive_service.xc
+++ b/module_network_drive/src/network_drive_service.xc
@@ -655,7 +655,8 @@ void network_drive_service(ProfilerConfig &profiler_config,
             read_configuration = 0;
             i_co.configuration_done();
             // check if there is there is any object that changed but was not read and if so read them to clear the flag
-            int changed_index, changed_subindex;
+            uint16_t changed_index = 0;
+            uint8_t changed_subindex = 0;
             { changed_index, changed_subindex } = i_co.od_get_next_changed_element();
             int timeout = 1000;
             while (changed_index && timeout>0) {


### PR DESCRIPTION
Now the configuration is read when:
 - Switch on disabled -> Ready to switch on transition
 - switching to tuning opmode
 - Fault state and at least one object is changed