### PR TITLE
Add GPIO support in ethercat drive

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 sc_sncn_ethercat_drive Change Log
 ==================================
 
+3.0.4
+-----
+
+  * Add GPIO support in ethercat drive
+
+
 3.0.3
 -----
 

--- a/examples/app_demo_master_cyclic/include/ecat_master.h
+++ b/examples/app_demo_master_cyclic/include/ecat_master.h
@@ -59,9 +59,6 @@ typedef struct {
 } PDOOutput;
 
 
-/*
- * Indexes of PDO elements
- */
 #define PDO_INDEX_STATUSWORD                  0
 #define PDO_INDEX_OPMODEDISP                  1
 #define PDO_INDEX_POSITION_VALUE              2
@@ -93,6 +90,14 @@ typedef struct {
 #define PDO_INDEX_DIGITAL_OUTPUT3            11
 #define PDO_INDEX_DIGITAL_OUTPUT4            13
 #define PDO_INDEX_USER_MOSI                  15
+
+
+/*
+ * Indexes of SDO elements
+ */
+#define DICT_FEEDBACK_SENSOR_PORTS                    0x2100
+#define SUB_ENCODER_FUNCTION                               2
+#define SUB_ENCODER_RESOLUTION                             3
 
 
 /*
@@ -148,18 +153,18 @@ int write_sdo(Ethercat_Slave_t *slave, SdoParam_t *conf);
  */
 int write_sdo_config(Ethercat_Master_t *master, int slave_number, SdoParam_t *config, size_t max_objects);
 
+
 /**
- * @brief Read a sdo object from a local saved sdo list
+ * @brief Read a sdo object from a slave
  *
- * @param slave   slave number
- * @param *config pointer to list of configuration objects
- * @param max_objects number of objects to transfer
+ * @param master  pointer to the master device
+ * @param slave_number   slave number
  * @param index of the object
  * @param subindex of the object
  *
- * @return value of the object, 0 or if not found
+ * @return value of the object, -1 or if not found
  */
-int read_local_sdo(int slave_number, SdoParam_t **config, size_t max_objects, int index, int subindex);
+int read_sdo(Ethercat_Master_t *master, int slave_number, int index, int subindex);
 
 #ifdef __cplusplus
 }

--- a/examples/app_demo_master_cyclic/src/ecat_master.c
+++ b/examples/app_demo_master_cyclic/src/ecat_master.c
@@ -166,12 +166,17 @@ int write_sdo_config(Ethercat_Master_t *master, int slave_number, SdoParam_t *co
     return ret;
 }
 
-int read_local_sdo(int slave_number, SdoParam_t **config, size_t max_objects, int index, int subindex)
-{
-    for (int i=0 ; i<max_objects; i++) {
-        if (config[slave_number][i].index == index && config[slave_number][i].subindex == subindex) {
-            return config[slave_number][i].value;
-        }
+int read_sdo(Ethercat_Master_t *master, int slave_number, int index, int subindex) {
+    int sdo_value = 0;
+
+    int ret = ecw_slave_get_sdo_value(ecw_slave_get(master, slave_number), index, subindex, &sdo_value);
+
+    if (ret == 0) {
+        return sdo_value;
+    } else {
+        fprintf(stderr, "Error Slave %d, could not read sdo object 0x%04x:%d, error code %d\n",
+                slave_number, index, subindex, ret);
     }
-    return 0;
+
+    return -1;
 }

--- a/examples/app_demo_master_ethercat_tuning/doc/index.rst
+++ b/examples/app_demo_master_ethercat_tuning/doc/index.rst
@@ -111,6 +111,7 @@ The number can be negative. Spaces are ignored. The default number value is 0.
   - ``m``: toggle the phase inverted parameter. Use this if after finding the offset you have a positive torque resulting in a negative velocity.
   - ``P[number]``: set the pole pairs. If when using torque control and the motor moves a little bit then "hold" a position it can be because the pole pairs are incorrect. (it can also be caused by the position sensor).
   - ``f``: reset the motorcontrol fault. If the motor stops because of over/under current. Try adjusting you power supply settings and maybe set a lower maximum torque.
+  - ``g[number]``: set the GPIO output. The number to input must be four ``0`` or ``1``. GPIO port 1 is the rightmost bit.
   - ``tss``: set the torque safe mode. in this mode all the phases are disconnected and the motor is free to move. Use this if you want to manually move the axis.
   - ``kpp [number]``: set the P coefficient of the Position controller.
   - ``kpi [number]``: set the I coefficient of the Position controller.
@@ -175,7 +176,7 @@ When the application has been compiled, the next step is to run it on the Linux 
         Position D        41000 | Velocity D             0
         Position I lim     1000 | Velocity I lim       900
         Autotune Period    2000 | Amplitude          20000
-        Filter                0
+        Filter                0 | GPIO input: xxxx / output: xxxx
         * Motor Fault Under Voltage *
 
 

--- a/examples/app_demo_master_ethercat_tuning/include/ecat_sdo_config.h
+++ b/examples/app_demo_master_ethercat_tuning/include/ecat_sdo_config.h
@@ -17,6 +17,20 @@
 extern "C" {
 #endif
 
+
+/*
+ * Indexes of SDO elements
+ */
+#define DICT_GPIO                                     0x2210
+#define SUB_GPIO_PIN_1                                     1
+#define SUB_GPIO_PIN_2                                     2
+#define SUB_GPIO_PIN_3                                     3
+#define SUB_GPIO_PIN_4                                     4
+#define DICT_FEEDBACK_SENSOR_PORTS                    0x2100
+#define SUB_ENCODER_FUNCTION                               2
+#define SUB_ENCODER_RESOLUTION                             3
+
+
 /**
  * @brief configuration object for SDO download
  */
@@ -58,7 +72,19 @@ int write_sdo_config(Ethercat_Master_t *master, int slave_number, SdoParam_t *co
  *
  * @return value of the object, 0 or if not found
  */
-int read_sdo(int slave_number, SdoParam_t **config, size_t max_objects, int index, int subindex);
+int read_sdo_from_file(int slave_number, SdoParam_t **config, size_t max_objects, int index, int subindex);
+
+/**
+ * @brief Read a sdo object from a slave
+ *
+ * @param master  pointer to the master device
+ * @param slave_number   slave number
+ * @param index of the object
+ * @param subindex of the object
+ *
+ * @return value of the object, -1 or if not found
+ */
+int read_sdo(Ethercat_Master_t *master, int slave_number, int index, int subindex);
 
 #ifdef __cplusplus
 }

--- a/examples/app_demo_master_ethercat_tuning/include/tuning.h
+++ b/examples/app_demo_master_ethercat_tuning/include/tuning.h
@@ -132,6 +132,16 @@ typedef enum {
     CS_MODE
 } AppMode;
 
+/**
+ * @brief GPIO port type
+ */
+typedef enum {
+    GPIO_OFF=0,             /**< GPIO port off */
+    GPIO_INPUT,             /**< Input GPIO port */
+    GPIO_INPUT_PULLDOWN,    /**< Input GPIO port with pulldown */
+    GPIO_OUTPUT             /**< Output GPIO port */
+} GPIOType;
+
 typedef struct {
     TuningMotorCtrlStatus motorctrl_status;
     int offset;
@@ -161,6 +171,7 @@ typedef struct {
     int filter;
     int tune_amplitude;
     int tune_period;
+    GPIOType gpio_config[4];        /**< GPIO configuration */
 } InputValues;
 
 typedef struct {

--- a/examples/app_demo_master_ethercat_tuning/sdo_config/sdo_config.csv
+++ b/examples/app_demo_master_ethercat_tuning/sdo_config/sdo_config.csv
@@ -54,6 +54,12 @@
 0x2010,        3,           0,           0,           0,           0,           0,           0 # TORQUE_Kd
 0x200A,        0,           0,           0,           0,           0,           0,           0 # MOMENT_OF_INERTIA [g·m2]
 
+#GPIO config
+0x2210,        1,           0,           0,           0,           0,           0,           0 # GPIO 1 [0:3] - 0: disabled, 1:input (without pull-down), 2: input active high (pull-down resistor activated), 3: output
+0x2210,        2,           0,           0,           0,           0,           0,           0 # GPIO 2 [0:3] - 0: disabled, 1:input (without pull-down), 2: input active high (pull-down resistor activated), 3: output
+0x2210,        3,           0,           0,           0,           0,           0,           0 # GPIO 3 [0:3] - 0: disabled, 1:input (without pull-down), 2: input active high (pull-down resistor activated), 3: output
+0x2210,        4,           0,           0,           0,           0,           0,           0 # GPIO 4 [0:3] - 0: disabled, 1:input (without pull-down), 2: input active high (pull-down resistor activated), 3: output
+
 #sensor config
 0x607C,        0,           0,           0,           0,           0,           0,           0 # HOME_OFFSET [encoder increments (ticks)]
 0x2100,        1,           0,           0,           0,           0,           0,           0 # FEEDBACK_SENSOR_PORTS - IFM HW port 1: assign here your used sensor object

--- a/examples/app_demo_master_ethercat_tuning/src/display.c
+++ b/examples/app_demo_master_ethercat_tuning/src/display.c
@@ -185,6 +185,21 @@ int display_tuning(WINDOW *wnd, struct _pdo_cia402_output pdo_output, struct _pd
     //row 14
     wmoveclr(wnd, &row);
     wprintw(wnd, "Filter         %8d", input.filter);
+    char gpio_input[5];
+    char gpio_output[5];
+    sprintf(gpio_input, "%c%c%c%c", '0'+pdo_input.digital_input4,  '0'+pdo_input.digital_input3, '0'+pdo_input.digital_input2, '0'+pdo_input.digital_input1);
+    sprintf(gpio_output, "%c%c%c%c", '0'+pdo_output.digital_output4, '0'+pdo_output.digital_output3, '0'+pdo_output.digital_output2, '0'+pdo_output.digital_output1);
+    for (int i=0; i<4; i++) {
+        if (input.gpio_config[i] == GPIO_OFF) {
+            gpio_input[3-i] = 'x';
+            gpio_output[3-i] = 'x';
+        } else if (input.gpio_config[i] == GPIO_OUTPUT) {
+            gpio_input[3-i] = 'x';
+        } else if (input.gpio_config[i] == GPIO_INPUT || input.gpio_config[i] == GPIO_INPUT_PULLDOWN) {
+            gpio_output[3-i] = 'x';
+        }
+    }
+    wprintw(wnd, " | GPIO input: %s / output: %s", gpio_input, gpio_output);
     //row 15
     wmoveclr(wnd, &row);
     //motorcontrol fault

--- a/examples/app_demo_master_ethercat_tuning/src/ecat_sdo_config.c
+++ b/examples/app_demo_master_ethercat_tuning/src/ecat_sdo_config.c
@@ -46,7 +46,7 @@ int write_sdo_config(Ethercat_Master_t *master, int slave_number, SdoParam_t *co
     return ret;
 }
 
-int read_sdo(int slave_number, SdoParam_t **config, size_t max_objects, int index, int subindex)
+int read_sdo_from_file(int slave_number, SdoParam_t **config, size_t max_objects, int index, int subindex)
 {
     for (int i=0 ; i<max_objects; i++) {
         if (config[slave_number][i].index == index && config[slave_number][i].subindex == subindex) {
@@ -54,4 +54,19 @@ int read_sdo(int slave_number, SdoParam_t **config, size_t max_objects, int inde
         }
     }
     return 0;
+}
+
+int read_sdo(Ethercat_Master_t *master, int slave_number, int index, int subindex) {
+    int sdo_value = 0;
+
+    int ret = ecw_slave_get_sdo_value(ecw_slave_get(master, slave_number), index, subindex, &sdo_value);
+
+    if (ret == 0) {
+        return sdo_value;
+    } else {
+        fprintf(stderr, "Error Slave %d, could not read sdo object 0x%04x:%d, error code %d\n",
+                slave_number, index, subindex, ret);
+    }
+
+    return -1;
 }

--- a/examples/app_demo_master_ethercat_tuning/src/tuning.c
+++ b/examples/app_demo_master_ethercat_tuning/src/tuning.c
@@ -457,6 +457,25 @@ void tuning_command(WINDOW *wnd, struct _pdo_cia402_output *pdo_output, struct _
                 } /* end mode_2 */
                 break;
 
+            //GPIO output
+            case 'g':
+                if (output->value <= 1111) {
+                    char * input = malloc(5*sizeof(char));
+                    sprintf(input, "%04d", output->value);
+                    uint8_t gpio_output = 0;
+                    for (int i=3; i>=0; i--) {
+                        if (input[i] != '0') {
+                            gpio_output |= 0b1000 >> i;
+                        }
+                    }
+                    free(input);
+                    pdo_output->digital_output1 = (gpio_output & 0b0001);
+                    pdo_output->digital_output2 = (gpio_output & 0b0010) >> 1;
+                    pdo_output->digital_output3 = (gpio_output & 0b0100) >> 2;
+                    pdo_output->digital_output4 = (gpio_output & 0b1000) >> 3;
+                }
+                break;
+
 
             // default is enable torque control and set torque command
             // if the value is 0 stop everything. So just pressing Enter without a command act as an emergency stop

--- a/examples/app_demo_slave_ethercat_motorcontrol/src/main.xc
+++ b/examples/app_demo_slave_ethercat_motorcontrol/src/main.xc
@@ -267,6 +267,11 @@ int main(void)
 
                     position_feedback_config_1.hall_config.port_number = HALL_SENSOR_PORT_NUMBER;
 
+                    position_feedback_config_1.gpio_config[0] = GPIO_CONFIG_1;
+                    position_feedback_config_1.gpio_config[1] = GPIO_CONFIG_2;
+                    position_feedback_config_1.gpio_config[2] = GPIO_CONFIG_3;
+                    position_feedback_config_1.gpio_config[3] = GPIO_CONFIG_4;
+
                     //setting second sensor
                     PositionFeedbackConfig position_feedback_config_2 = position_feedback_config_1;
                     position_feedback_config_2.sensor_type = 0;

--- a/module_ethercat_drive/src/ethercat_drive_service.xc
+++ b/module_ethercat_drive/src/ethercat_drive_service.xc
@@ -475,6 +475,8 @@ void ethercat_drive_service(ProfilerConfig &profiler_config,
         target_velocity = pdo_get_target_velocity(InOut);
         target_torque   = (pdo_get_target_torque(InOut)*motorcontrol_config.rated_torque) / 1000; //target torque received in 1/1000 of rated torque
         send_to_control.offset_torque = (pdo_get_offset_torque(InOut)*motorcontrol_config.rated_torque) / 1000; //offset torque received in 1/1000 of rated torque
+        send_to_control.gpio_output = ((pdo_get_digital_output4(InOut)&1) << 3) | ((pdo_get_digital_output3(InOut)&1) << 2)
+                                    | ((pdo_get_digital_output2(InOut)&1) << 1)| (pdo_get_digital_output1(InOut) & 1);
 
         /* tuning pdos */
         tuning_command = pdo_get_tuning_command(InOut); // mode 3, 2 and 1 in tuning command
@@ -587,6 +589,11 @@ void ethercat_drive_service(ProfilerConfig &profiler_config,
         pdo_set_tuning_status(tuning_status, InOut);
         pdo_set_user_miso(user_miso, InOut);
         pdo_set_timestamp(send_to_master.sensor_timestamp, InOut);
+        // send gpio input to master
+        pdo_set_digital_input1(send_to_master.gpio[0], InOut);
+        pdo_set_digital_input2(send_to_master.gpio[1], InOut);
+        pdo_set_digital_input3(send_to_master.gpio[2], InOut);
+        pdo_set_digital_input4(send_to_master.gpio[3], InOut);
 
 //        xscope_int(ACTUAL_VELOCITY, actual_velocity);
 //        xscope_int(ACTUAL_POSITION, actual_position);


### PR DESCRIPTION
- add sending GPIO input to the master
- add reading GPIO output from the master and sending to Motion control -> Torque control -> Shared Memory -> Position feedback service.
- add GPIO input display and output command in ethercat tuning