### PR TITLE
Fix loading the torque array from flash in ethercat drive

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ sc_sncn_ethercat_drive Change Log
 -----
 
   * Integrate GPIO service in ethercat drive enabled for SDK 3.0.4
+  * Fix loading torque array from flash
   
 
 3.1.1

--- a/module_file_service/src/file_service.xc
+++ b/module_file_service/src/file_service.xc
@@ -423,7 +423,7 @@ void file_service(
                         int err_write = i_spiffs.write(file_id, data, 2);
                         if (err_write < 0)
                         {
-                            printf("error writting torque array: %d\n", err_write);
+                            printf("error writing torque array: %d\n", err_write);
                             status = FS_TORQUE_ERR;
                         }
 

--- a/module_file_service/src/file_service.xc
+++ b/module_file_service/src/file_service.xc
@@ -240,7 +240,7 @@ static int received_filechunk_from_master(struct _file_t &file, client interface
         }
         else
         {
-            printstr("Writed: ");
+            printstr("Written: ");
             printintln(write_result);
 
             if (stat == FOE_STAT_EOF) {
@@ -423,7 +423,7 @@ void file_service(
                         int err_write = i_spiffs.write(file_id, data, 2);
                         if (err_write < 0)
                         {
-                            printf("error : %d\n", err_write);
+                            printf("error writting torque array: %d\n", err_write);
                             status = FS_TORQUE_ERR;
                         }
 
@@ -432,11 +432,9 @@ void file_service(
                     break;
 
             case i_file_service[int i].read_torque_array(int array_out[]) -> int status:
-                    printf("Read torque array\n");
                     int file_id = i_spiffs.open_file(TORQUE_OFFSET_FILE_NAME, strlen(TORQUE_OFFSET_FILE_NAME), (SPIFFS_RDONLY));
                     if (file_id < 0)
                     {
-                        printstrln("Error opening file");
                         if (file_id == SPIFFS_ERR_NOT_FOUND)
                             status = SPIFFS_ERR_NOT_FOUND;
                         else
@@ -445,8 +443,6 @@ void file_service(
                     }
                     else
                     {
-                        printstr("File opened: ");
-                        printintln(file_id);
                         status = FS_TORQUE_OK;
                     }
 
@@ -456,7 +452,7 @@ void file_service(
                         int err_read = i_spiffs.read(file_id, buffer, 2);
                         if (err_read < 0)
                         {
-                            printf("error : %d\n", err_read);
+                            printf("error reading torque array: %d\n", err_read);
                             status = FS_TORQUE_ERR;
                         }
 

--- a/module_network_drive/src/network_drive_service.xc
+++ b/module_network_drive/src/network_drive_service.xc
@@ -657,8 +657,11 @@ void network_drive_service(ProfilerConfig &profiler_config,
             //Load cogging torque data
             char filename [] = "cogging_torque.bin";
             int status = i_file_service.read_torque_array(motorcontrol_config.torque_offset);
-            if (status != SPIFFS_ERR_NOT_FOUND)
+            if (status != SPIFFS_ERR_NOT_FOUND) {
+                i_torque_control.set_config(motorcontrol_config);
                 i_motion_control.enable_cogging_compensation(1);
+                tuning_mode_state.cogging_torque_flag = 1;
+            }
 
 
             tuning_mode_state.flags = tuning_set_flags(tuning_mode_state, motorcontrol_config, motion_control_config,


### PR DESCRIPTION
Now if a file is found and loaded it will enable the cogging torque compensation and display it in the tuning app.

Also cleaned up some prints in the file service.