### PR TITLE
Fix usage of Position range limit and Software position limit objects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ sc_sncn_ethercat_drive Change Log
 
   * Add GPIO support in ethercat drive
   * Fix bugs in setting/getting motion_control_config struct in config manager
+  * Fix usage of Position range limit (0x607B) and Software position limit (0x607D) objects
 
 
 3.0.3

--- a/examples/app_demo_slave_ethercat_motorcontrol/src/main.xc
+++ b/examples/app_demo_slave_ethercat_motorcontrol/src/main.xc
@@ -25,11 +25,8 @@
 #include <adc_service.h>
 #include <watchdog_service.h>
 #include <motor_control_interfaces.h>
-#include <advanced_motor_control.h>
-
-//Position control + profile libs
 #include <motion_control_service.h>
-#include <profile_control.h>
+#include <advanced_motor_control.h>
 
 EthercatPorts ethercat_ports = SOMANET_COM_ETHERCAT_PORTS;
 PwmPorts pwm_ports = SOMANET_IFM_PWM_PORTS;
@@ -87,17 +84,7 @@ int main(void)
         /* EtherCAT Motor Drive Loop */
         on tile[APP_TILE_1] :
         {
-            ProfilerConfig profiler_config;
-
-            profiler_config.max_position = MAX_POSITION_RANGE_LIMIT;   /* Set by Object Dictionary value! */
-            profiler_config.min_position = MIN_POSITION_RANGE_LIMIT;   /* Set by Object Dictionary value! */
-
-            profiler_config.max_velocity = MOTOR_MAX_SPEED;
-            profiler_config.max_acceleration = MAX_ACCELERATION_PROFILER;
-            profiler_config.max_deceleration = MAX_DECELERATION_PROFILER;
-
-            ethercat_drive_service( profiler_config,
-                                    i_pdo, i_coe,
+            ethercat_drive_service( i_pdo, i_coe,
                                     i_torque_control[1],
                                     i_motion_control[0], i_position_feedback_1[0], i_position_feedback_2[0]);
         }

--- a/examples/app_demo_slave_ethercat_motorcontrol/src/main.xc
+++ b/examples/app_demo_slave_ethercat_motorcontrol/src/main.xc
@@ -25,8 +25,8 @@
 #include <adc_service.h>
 #include <watchdog_service.h>
 #include <motor_control_interfaces.h>
-#include <motion_control_service.h>
 #include <advanced_motor_control.h>
+#include <motion_control_service.h>
 
 EthercatPorts ethercat_ports = SOMANET_COM_ETHERCAT_PORTS;
 PwmPorts pwm_ports = SOMANET_IFM_PWM_PORTS;

--- a/module_ethercat_drive/include/config_manager.h
+++ b/module_ethercat_drive/include/config_manager.h
@@ -13,15 +13,6 @@
 #include <motion_control_service.h>
 #include <profile_control.h>
 
-/* Define which type a given profiler configuration is
- * FIXME could be added into ProfilerConfig!
- */
-enum eProfileType {
-    PROFILE_TYPE_UNKNOWN = 0
-    ,PROFILE_TYPE_POSITION
-    ,PROFILE_TYPE_VELOCITY
-};
-
 /*
  * General, syncronize configuration with the object dictionary values provided
  * by the EtherCAT master.
@@ -40,12 +31,6 @@ int cm_sync_config_motor_control(
         MotorcontrolConfig &commutation_params,
         int sensor_commutation,
         int sensor_commutation_type);
-
-
-void cm_sync_config_profiler(
-        client interface i_coe_communication i_coe,
-        ProfilerConfig &profiler,
-        enum eProfileType type);
 
 void cm_sync_config_pos_velocity_control(
         client interface i_coe_communication i_coe,
@@ -69,10 +54,6 @@ void cm_default_config_motor_control(
         client interface i_coe_communication i_coe,
         client interface TorqueControlInterface ?i_torque_control,
         MotorcontrolConfig &commutation_params);
-
-void cm_default_config_profiler(
-        client interface i_coe_communication i_coe,
-        ProfilerConfig &profiler);
 
 void cm_default_config_pos_velocity_control(
         client interface i_coe_communication i_coe,

--- a/module_ethercat_drive/include/ethercat_drive_service.h
+++ b/module_ethercat_drive/include/ethercat_drive_service.h
@@ -17,7 +17,6 @@
 /**
  * @brief This Service enables motor drive functions via EtherCAT.
  *
- * @param profiler_config Configuration for profile mode control.
  * @param i_pdo Channel to send and receive information to EtherCAT Service.
  * @param i_coe Channel to receive motor configuration information from EtherCAT Service.
  * @param i_torque_control Interface to Motor Control Service
@@ -25,8 +24,7 @@
  * @param i_position_feedback_1 Interface to the fisrt sensor service
  * @param i_position_feedback_2 Interface to the second sensor service
  */
-void ethercat_drive_service(ProfilerConfig &profiler_config,
-                            client interface i_pdo_communication i_pdo,
+void ethercat_drive_service(client interface i_pdo_communication i_pdo,
                             client interface i_coe_communication i_coe,
                             client interface TorqueControlInterface i_torque_control,
                             client interface MotionControlInterface i_motion_control,

--- a/module_ethercat_drive/src/config_manager.xc
+++ b/module_ethercat_drive/src/config_manager.xc
@@ -206,8 +206,8 @@ void cm_sync_config_pos_velocity_control(
     position_config = i_motion_control.get_motion_control_config();
 
     //limits
-    position_config.min_pos_range_limit = i_coe.get_object_value(DICT_POSITION_RANGE_LIMITS, SUB_POSITION_RANGE_LIMITS_MIN_POSITION_RANGE_LIMIT);
-    position_config.max_pos_range_limit = i_coe.get_object_value(DICT_POSITION_RANGE_LIMITS, SUB_POSITION_RANGE_LIMITS_MAX_POSITION_RANGE_LIMIT);
+    position_config.min_pos_range_limit = i_coe.get_object_value(DICT_MAX_SOFTWARE_POSITION_RANGE_LIMIT, SUB_POSITION_RANGE_LIMITS_MIN_POSITION_RANGE_LIMIT);
+    position_config.max_pos_range_limit = i_coe.get_object_value(DICT_MAX_SOFTWARE_POSITION_RANGE_LIMIT, SUB_POSITION_RANGE_LIMITS_MAX_POSITION_RANGE_LIMIT);
     position_config.max_motor_speed     = i_coe.get_object_value(DICT_MAX_MOTOR_SPEED, 0);
     position_config.max_torque          = max_torque;
 
@@ -404,8 +404,8 @@ void cm_default_config_pos_velocity_control(
     position_config = i_motion_control.get_motion_control_config();
 
     //limits
-    i_coe.set_object_value(DICT_POSITION_RANGE_LIMITS, SUB_POSITION_RANGE_LIMITS_MIN_POSITION_RANGE_LIMIT, position_config.min_pos_range_limit);
-    i_coe.set_object_value(DICT_POSITION_RANGE_LIMITS, SUB_POSITION_RANGE_LIMITS_MAX_POSITION_RANGE_LIMIT, position_config.max_pos_range_limit);
+    i_coe.set_object_value(DICT_MAX_SOFTWARE_POSITION_RANGE_LIMIT, SUB_POSITION_RANGE_LIMITS_MIN_POSITION_RANGE_LIMIT, position_config.min_pos_range_limit);
+    i_coe.set_object_value(DICT_MAX_SOFTWARE_POSITION_RANGE_LIMIT, SUB_POSITION_RANGE_LIMITS_MAX_POSITION_RANGE_LIMIT, position_config.max_pos_range_limit);
     i_coe.set_object_value(DICT_MAX_MOTOR_SPEED, 0, position_config.max_motor_speed);
 
     //if the internal polarity is inverted enable inverted position and velocity polarity bits in the DICT_POLARITY object

--- a/module_ethercat_drive/src/config_manager.xc
+++ b/module_ethercat_drive/src/config_manager.xc
@@ -196,21 +196,6 @@ int cm_sync_config_motor_control(
     return motorcontrol_config.max_torque;
 }
 
-void cm_sync_config_profiler(
-        client interface i_coe_communication i_coe,
-        ProfilerConfig &profiler,
-        enum eProfileType type)
-{
-    profiler.min_position     =  i_coe.get_object_value(DICT_MAX_SOFTWARE_POSITION_RANGE_LIMIT, 1);
-    profiler.max_position     =  i_coe.get_object_value(DICT_MAX_SOFTWARE_POSITION_RANGE_LIMIT, 2);
-    profiler.acceleration     =  i_coe.get_object_value(DICT_PROFILE_ACCELERATION, 0);
-    profiler.deceleration     =  i_coe.get_object_value(DICT_PROFILE_DECELERATION, 0);
-    profiler.max_velocity     =  i_coe.get_object_value(DICT_MAX_PROFILE_VELOCITY, 0);
-    profiler.max_deceleration =  profiler.deceleration;
-    profiler.max_acceleration =  i_coe.get_object_value(DICT_PROFILE_ACCELERATION, 0);
-    profiler.velocity         =  i_coe.get_object_value(DICT_MAX_PROFILE_VELOCITY, 0);
-}
-
 void cm_sync_config_pos_velocity_control(
         client interface i_coe_communication i_coe,
         client interface MotionControlInterface i_motion_control,
@@ -408,19 +393,6 @@ void cm_default_config_motor_control(
     i_coe.set_object_value(DICT_HALL_SENSOR_2, SUB_HALL_SENSOR_STATE_ANGLE_5, motorcontrol_config.hall_state_angle[5]);
 
     //FIXME: missing motorcontrol_config.protection_limit_over_temperature
-}
-
-void cm_default_config_profiler(
-        client interface i_coe_communication i_coe,
-        ProfilerConfig &profiler)
-{
-    i_coe.set_object_value(DICT_MAX_SOFTWARE_POSITION_RANGE_LIMIT, 1, profiler.min_position);
-    i_coe.set_object_value(DICT_MAX_SOFTWARE_POSITION_RANGE_LIMIT, 2, profiler.max_position);
-    i_coe.set_object_value(DICT_PROFILE_ACCELERATION, 0, profiler.acceleration);
-    i_coe.set_object_value(DICT_PROFILE_DECELERATION, 0, profiler.deceleration);
-    i_coe.set_object_value(DICT_MAX_PROFILE_VELOCITY, 0, profiler.max_velocity);
-    i_coe.set_object_value(DICT_PROFILE_ACCELERATION, 0, profiler.max_acceleration);
-    i_coe.set_object_value(DICT_MAX_PROFILE_VELOCITY, 0, profiler.velocity);
 }
 
 void cm_default_config_pos_velocity_control(

--- a/module_ethercat_drive/src/ethercat_drive_service.xc
+++ b/module_ethercat_drive/src/ethercat_drive_service.xc
@@ -194,12 +194,10 @@ static void inline update_configuration(
         PositionFeedbackConfig    &position_feedback_config_2,
         MotorcontrolConfig        &motorcontrol_config,
         int &sensor_commutation, int &sensor_motion_control,
-        int &limit_switch_type,
         int &sensor_resolution,
         uint8_t &polarity,
-        int &nominal_speed,
-        int &homing_method,
-        int &quick_stop_deceleration)
+        int &quick_stop_deceleration,
+        int &position_range_limit_min, int &position_range_limit_max)
 {
 
     // set position feedback services parameters
@@ -239,11 +237,21 @@ static void inline update_configuration(
     cm_sync_config_pos_velocity_control(i_coe, i_motion_control, position_config, sensor_resolution, max_torque);
 
     /* Update values with current configuration */
-    nominal_speed     = i_coe.get_object_value(DICT_MAX_MOTOR_SPEED, 0);
-    limit_switch_type = 0; //i_coe.get_object_value(LIMIT_SWITCH_TYPE, 0); /* not used now */
-    homing_method     = 0; //i_coe.get_object_value(CIA402_HOMING_METHOD, 0); /* not used now */
     polarity          = i_coe.get_object_value(DICT_POLARITY, 0);
     quick_stop_deceleration = i_coe.get_object_value(DICT_QUICK_STOP_DECELERATION, 0);
+    position_range_limit_min = i_coe.get_object_value(DICT_POSITION_RANGE_LIMITS, SUB_POSITION_RANGE_LIMITS_MIN_POSITION_RANGE_LIMIT);
+    position_range_limit_max = i_coe.get_object_value(DICT_POSITION_RANGE_LIMITS, SUB_POSITION_RANGE_LIMITS_MAX_POSITION_RANGE_LIMIT);
+    // add home offset to range limit and check overflow
+    int home_offset = i_coe.get_object_value(DICT_HOME_OFFSET, 0);
+    int temp = 0;
+    temp = position_range_limit_min + home_offset;
+    if ( (home_offset >= 0 && temp >= position_range_limit_min) || (home_offset < 0 && temp < position_range_limit_min) ) { //no overflow
+        position_range_limit_min = temp;
+    }
+    temp = position_range_limit_max + home_offset;
+    if ( (home_offset >= 0 && temp >= position_range_limit_max) || (home_offset < 0 && temp < position_range_limit_max) ) { //no overflow
+        position_range_limit_max = temp;
+    }
 }
 
 static void motioncontrol_enable(int opmode, int position_control_strategy,
@@ -345,7 +353,6 @@ void ethercat_drive_service(client interface i_pdo_communication i_pdo,
 
     enum eDirection direction = DIRECTION_NEUTRAL;
 
-    int nominal_speed;
     timer t;
 
     int opmode = OPMODE_NONE;
@@ -380,11 +387,10 @@ void ethercat_drive_service(client interface i_pdo_communication i_pdo,
     check_list checklist = init_checklist();
     unsigned int fault_reset_wait_time;
 
-    int limit_switch_type;
-    int homing_method;
-
     int sensor_resolution = 0;
     uint8_t polarity = 0;
+    int position_range_limit_min = motion_control_config.min_pos_range_limit;
+    int position_range_limit_max = motion_control_config.max_pos_range_limit;
 
     PositionFeedbackConfig position_feedback_config_1 = i_position_feedback_1.get_config();
     PositionFeedbackConfig position_feedback_config_2;
@@ -414,6 +420,8 @@ void ethercat_drive_service(client interface i_pdo_communication i_pdo,
     cm_default_config_motor_control(i_coe, i_torque_control, motorcontrol_config);
     cm_default_config_pos_velocity_control(i_coe, i_motion_control, motion_control_config);
     i_coe.set_object_value(DICT_QUICK_STOP_DECELERATION, 0, motion_control_config.max_deceleration_profiler);
+    i_coe.set_object_value(DICT_POSITION_RANGE_LIMITS, SUB_POSITION_RANGE_LIMITS_MIN_POSITION_RANGE_LIMIT, position_range_limit_min);
+    i_coe.set_object_value(DICT_POSITION_RANGE_LIMITS, SUB_POSITION_RANGE_LIMITS_MAX_POSITION_RANGE_LIMIT, position_range_limit_max);
 
     /* check if the slave enters the operation mode. If this happens we assume the configuration values are
      * written into the object dictionary. So we read the object dictionary values and continue operation.
@@ -445,12 +453,12 @@ void ethercat_drive_service(client interface i_pdo_communication i_pdo,
                 break;
         }
 
-        /* FIXME: When to update configuration values from OD? only do this in state "Ready to Switch on"? */
+        /* update configuration values from OD */
         if (read_configuration) {
             update_configuration(i_coe, i_torque_control, i_motion_control, i_position_feedback_1, i_position_feedback_2,
                     motion_control_config, position_feedback_config_1, position_feedback_config_2, motorcontrol_config,
-                    sensor_commutation, sensor_motion_control, limit_switch_type, sensor_resolution, polarity, nominal_speed, homing_method,
-                    quick_stop_deceleration
+                    sensor_commutation, sensor_motion_control, sensor_resolution, polarity, quick_stop_deceleration,
+                    position_range_limit_min, position_range_limit_max
                     );
             tuning_mode_state.flags = tuning_set_flags(tuning_mode_state, motorcontrol_config, motion_control_config,
                     position_feedback_config_1, position_feedback_config_2, sensor_commutation);
@@ -473,6 +481,23 @@ void ethercat_drive_service(client interface i_pdo_communication i_pdo,
         /* tuning pdos */
         tuning_command = pdo_get_tuning_command(InOut); // mode 3, 2 and 1 in tuning command
         tuning_mode_state.value = pdo_get_user_mosi(InOut); // value of tuning command
+
+
+        /* position limit */
+        // first test Software position limit
+        if (target_position > motion_control_config.max_pos_range_limit) {
+            target_position = motion_control_config.max_pos_range_limit;
+        } else if (target_position < motion_control_config.min_pos_range_limit) {
+            target_position = motion_control_config.min_pos_range_limit;
+        } else {
+            // then test Position range limit (and wrap-around)
+            if (target_position > position_range_limit_max) {
+                target_position = position_range_limit_min + (target_position - position_range_limit_max)%(position_range_limit_max - position_range_limit_min);
+            } else if (target_position < position_range_limit_min) {
+                target_position = position_range_limit_max - (position_range_limit_min - target_position)%(position_range_limit_max - position_range_limit_min);
+            }
+        }
+
 
         /*
         printint(state);


### PR DESCRIPTION
- Software position limit (0x607D) is tested first, it just limits the position.
      The limit it on the position after applying the home offset.
      The position controller will limit the target position and additionally stop the motor and the brake if the limit is reached.
- Position range limit (0x607B) is tested after, it limits the targe position and additionally wrap-around the other end of the range.
      For example if the limits are -1000 and 1000 and the target is set to 1500 then it will be changed to -500.
      The limit is on the position before applying the home offset.

- also removed the profiler struct from ethercat_drive and config_manager because it was actually not used