### PR TITLE
Fix usage of Position range limit and Software position limit objects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ sc_sncn_ethercat_drive Change Log
 
   * Implement new pwm structure with 15 kHz, and use 100 MHz ref_clk_frq
   * Fix bugs in setting/getting motion_control_config struct in config manager
+  * Fix usage of Position range limit (0x607B) and Software position limit (0x607D) objects
 
 3.1.2
 -----

--- a/examples/app_demo_slave_ethercat_motorcontrol/src/main.xc
+++ b/examples/app_demo_slave_ethercat_motorcontrol/src/main.xc
@@ -29,10 +29,7 @@
 #include <watchdog_service.h>
 #include <motor_control_interfaces.h>
 #include <advanced_motor_control.h>
-
-//Position control + profile libs
 #include <motion_control_service.h>
-#include <profile_control.h>
 
 #include <flash_service.h>
 #include <spiffs_service.h>
@@ -103,16 +100,7 @@ int main(void)
 
 
                 {
-                    ProfilerConfig profiler_config;
-
-                    profiler_config.max_position = MAX_POSITION_RANGE_LIMIT;   /* Set by Object Dictionary value! */
-                    profiler_config.min_position = MIN_POSITION_RANGE_LIMIT;   /* Set by Object Dictionary value! */
-
-                    profiler_config.max_velocity = MOTOR_MAX_SPEED;
-                    profiler_config.max_acceleration = MAX_ACCELERATION_PROFILER;
-                    profiler_config.max_deceleration = MAX_DECELERATION_PROFILER;
-
-                    network_drive_service( profiler_config,
+                    network_drive_service(
                             i_pdo,
                             i_co[1],
                             i_torque_control[1],

--- a/module_network_drive/include/config_manager.h
+++ b/module_network_drive/include/config_manager.h
@@ -53,11 +53,6 @@ int cm_sync_config_motor_control(
         MotorcontrolConfig &commutation_params,
         int sensor_commutation_type);
 
-void cm_sync_config_profiler(
-        client interface i_co_communication i_co,
-        ProfilerConfig &profiler,
-        enum eProfileType type);
-
 void cm_sync_config_pos_velocity_control(
         client interface i_co_communication i_co,
         client interface MotionControlInterface i_motion_control,
@@ -89,10 +84,6 @@ void cm_default_config_motor_control(
         client interface i_co_communication i_co,
         client interface TorqueControlInterface ?i_torque_control,
         MotorcontrolConfig &commutation_params);
-
-void cm_default_config_profiler(
-        client interface i_co_communication i_co,
-        ProfilerConfig &profiler);
 
 void cm_default_config_pos_velocity_control(
         client interface i_co_communication i_co,

--- a/module_network_drive/include/network_drive_service.h
+++ b/module_network_drive/include/network_drive_service.h
@@ -25,7 +25,6 @@
 /**
  * @brief This Service enables motor drive functions with CANopen.
  *
- * @param profiler_config Configuration for profile mode control.
  * @param i_pdo Interface for PDOs to communication module.
  * @param i_od Interface for SDOs to CANopen service.
  * @param i_torque_control Interface to Motor Control Service
@@ -33,11 +32,10 @@
  * @param i_position_feedback_1 Interface to the fisrt sensor service
  * @param i_position_feedback_2 Interface to the second sensor service
  */
-void network_drive_service(ProfilerConfig &profiler_config,
-                            client interface i_pdo_handler_exchange i_pdo,
+void network_drive_service( client interface i_pdo_handler_exchange i_pdo,
                             client interface i_co_communication i_co,
                             client interface TorqueControlInterface i_torque_control,
                             client interface MotionControlInterface i_motion_control,
                             client interface PositionFeedbackInterface i_position_feedback_1,
                             client interface PositionFeedbackInterface ?i_position_feedback_2,
-                                    client interface FileServiceInterface i_file_service);
+                            client interface FileServiceInterface i_file_service);

--- a/module_network_drive/src/config_manager.xc
+++ b/module_network_drive/src/config_manager.xc
@@ -33,7 +33,7 @@ int cm_sync_config_position_feedback(
             {sensor_function, void, void} = i_co.od_get_object_value(feedback_sensor_object, 2);
             if (sensor_function != SENSOR_FUNCTION_DISABLED) {
                 // detect which position feedback service (1 or 2) is used for commutation or motion control
-                // this is used later for multiple things like: sensor resolution (for profiler), tuning (for setting the pole pairs)
+                // this is used later for multiple things like: sensor resolution (for quick stop, tuningc, setting the pole pairs)
                 switch(sensor_function) {
                 case SENSOR_FUNCTION_COMMUTATION_AND_MOTION_CONTROL:
                     sensor_commutation = feedback_service_index;
@@ -207,23 +207,6 @@ int cm_sync_config_motor_control(
     i_torque_control.set_config(motorcontrol_config);
 
     return motorcontrol_config.max_torque;
-}
-
-void cm_sync_config_profiler(
-        client interface i_co_communication i_co,
-        ProfilerConfig &profiler,
-        enum eProfileType type)
-{
-    {profiler.min_position, void, void} = i_co.od_get_object_value(DICT_MAX_SOFTWARE_POSITION_RANGE_LIMIT, 1);
-    {profiler.max_position, void, void} = i_co.od_get_object_value(DICT_MAX_SOFTWARE_POSITION_RANGE_LIMIT, 2);
-    {profiler.acceleration, void, void} = i_co.od_get_object_value(DICT_PROFILE_ACCELERATION, 0);
-    {profiler.deceleration, void, void} = i_co.od_get_object_value(DICT_PROFILE_DECELERATION, 0);
-    {profiler.max_velocity, void, void} = i_co.od_get_object_value(DICT_MAX_PROFILE_VELOCITY, 0);
-    /* FIXME this profiler is only used for Quick Stop so the max_deceleration is read from the quick stop deceleration */
-    profiler.max_deceleration =  profiler.deceleration;
-    //{profiler.max_deceleration, void, void} = i_co.od_get_object_value(DICT_QUICK_STOP_DECELERATION, 0);
-    {profiler.max_acceleration, void, void} = i_co.od_get_object_value(DICT_PROFILE_ACCELERATION, 0);
-    {profiler.velocity, void, void} = i_co.od_get_object_value(DICT_MAX_PROFILE_VELOCITY, 0);
 }
 
 void cm_sync_config_pos_velocity_control(
@@ -434,20 +417,6 @@ void cm_default_config_motor_control(
     i_co.od_set_object_value(DICT_PROTECTION, SUB_PROTECTION_MAX_DC_VOLTAGE, motorcontrol_config.protection_limit_over_voltage);
 
     //FIXME: missing motorcontrol_config.protection_limit_over_temperature
-}
-
-void cm_default_config_profiler(
-        client interface i_co_communication i_co,
-        ProfilerConfig &profiler)
-{
-    i_co.od_set_object_value(DICT_MAX_SOFTWARE_POSITION_RANGE_LIMIT, 1, profiler.min_position);
-    i_co.od_set_object_value(DICT_MAX_SOFTWARE_POSITION_RANGE_LIMIT, 2, profiler.max_position);
-    i_co.od_set_object_value(DICT_PROFILE_ACCELERATION, 0, profiler.acceleration);
-    i_co.od_set_object_value(DICT_PROFILE_DECELERATION, 0, profiler.deceleration);
-    i_co.od_set_object_value(DICT_MAX_PROFILE_VELOCITY, 0, profiler.max_velocity);
-    i_co.od_set_object_value(DICT_PROFILE_ACCELERATION, 0, profiler.max_acceleration);
-    i_co.od_set_object_value(DICT_MAX_PROFILE_VELOCITY, 0, profiler.velocity);
-    i_co.od_set_object_value(DICT_MAX_ACCELERATION, 0, profiler.max_acceleration);
 }
 
 void cm_default_config_pos_velocity_control(

--- a/module_network_drive/src/config_manager.xc
+++ b/module_network_drive/src/config_manager.xc
@@ -219,8 +219,8 @@ void cm_sync_config_pos_velocity_control(
     position_config = i_motion_control.get_motion_control_config();
 
     //limits
-    {position_config.min_pos_range_limit, void, void} = i_co.od_get_object_value(DICT_POSITION_RANGE_LIMITS, SUB_POSITION_RANGE_LIMITS_MIN_POSITION_RANGE_LIMIT);
-    {position_config.max_pos_range_limit, void, void} = i_co.od_get_object_value(DICT_POSITION_RANGE_LIMITS, SUB_POSITION_RANGE_LIMITS_MAX_POSITION_RANGE_LIMIT);
+    {position_config.min_pos_range_limit, void, void} = i_co.od_get_object_value(DICT_MAX_SOFTWARE_POSITION_RANGE_LIMIT, SUB_MAX_SOFTWARE_POSITION_RANGE_LIMIT_MIN_POSITION_LIMIT);
+    {position_config.max_pos_range_limit, void, void} = i_co.od_get_object_value(DICT_MAX_SOFTWARE_POSITION_RANGE_LIMIT, SUB_MAX_SOFTWARE_POSITION_RANGE_LIMIT_MAX_POSITION_LIMIT);
     {position_config.max_motor_speed, void, void} = i_co.od_get_object_value(DICT_MAX_MOTOR_SPEED, 0);
     position_config.max_torque          = max_torque;
 
@@ -428,8 +428,8 @@ void cm_default_config_pos_velocity_control(
     position_config = i_motion_control.get_motion_control_config();
 
     //limits
-    i_co.od_set_object_value(DICT_POSITION_RANGE_LIMITS, SUB_POSITION_RANGE_LIMITS_MIN_POSITION_RANGE_LIMIT, position_config.min_pos_range_limit);
-    i_co.od_set_object_value(DICT_POSITION_RANGE_LIMITS, SUB_POSITION_RANGE_LIMITS_MAX_POSITION_RANGE_LIMIT, position_config.max_pos_range_limit);
+    i_co.od_set_object_value(DICT_MAX_SOFTWARE_POSITION_RANGE_LIMIT, SUB_MAX_SOFTWARE_POSITION_RANGE_LIMIT_MIN_POSITION_LIMIT, position_config.min_pos_range_limit);
+    i_co.od_set_object_value(DICT_MAX_SOFTWARE_POSITION_RANGE_LIMIT, SUB_MAX_SOFTWARE_POSITION_RANGE_LIMIT_MAX_POSITION_LIMIT, position_config.max_pos_range_limit);
     i_co.od_set_object_value(DICT_MAX_MOTOR_SPEED, 0, position_config.max_motor_speed);
 
     //if the internal polarity is inverted enable inverted position and velocity polarity bits in the DICT_POLARITY object


### PR DESCRIPTION
Same as done on master branch.

- Software position limit (0x607D) is tested first, it just limits the position.
      The limit it on the position after applying the home offset.
      The position controller will limit the target position and additionally stop the motor and the brake if the limit is reached.
- Position range limit (0x607B) is tested after, it limits the targe position and additionally wrap-around the other end of the range.
      For example if the limits are -1000 and 1000 and the target is set to 1500 then it will be changed to -500.
      The limit is on the position before applying the home offset.

- also removed the profiler struct from ethercat_drive and config_manager because it was actually not used