### PR TITLE
Cleanup Network Drive Service

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ sc_sncn_ethercat_drive Change Log
   * Implement new pwm structure with 15 kHz, and use 100 MHz ref_clk_frq
   * Fix bugs in setting/getting motion_control_config struct in config manager
   * Fix usage of Position range limit (0x607B) and Software position limit (0x607D) objects
+  * Remove unnecessary calls to torque controller and do some cleanup in Network drive service
 
 3.1.2
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ sc_sncn_ethercat_drive Change Log
   * Fix bugs in setting/getting motion_control_config struct in config manager
   * Fix usage of Position range limit (0x607B) and Software position limit (0x607D) objects
   * Remove unnecessary calls to torque controller and do some cleanup in Network drive service
+  * Rename motorcontrol_config to torque_control_config
 
 3.1.2
 -----

--- a/examples/app_demo_master_ethercat_tuning/doc/index.rst
+++ b/examples/app_demo_master_ethercat_tuning/doc/index.rst
@@ -69,8 +69,8 @@ The commands consist of 1,2 or 3 characters with an optional number. The command
 The following one character commands are executed directly without pressing enter after:
 
   - ``q``: stop the node and quit the app
-  - ``[enter]``: just pressing enter will disable the motorcontrol block the brake.
-  - ``0``: pressing 0 will switch to torque control mode with a 0 torque command. Which stops the motor slower than by disabling the motorcontrol with ``[enter]``. Be careful if the axis is loaded it could fall.
+  - ``[enter]``: just pressing enter will disable the torque controller block the brake.
+  - ``0``: pressing 0 will switch to torque control mode with a 0 torque command. Which stops the motor slower than by disabling the torque controller with ``[enter]``. Be careful if the axis is loaded it could fall.
   - ``r``: reverse the current torque/velocity command
   - ``.``: start/stop record. this record the position/velocity/torque to a csv formated file.
   - ``[backspace]``: discard current command
@@ -107,7 +107,7 @@ The number can be negative. Spaces are ignored. The default number value is 0.
   - ``ev1``: enable velocity control.
   - ``et1``: enable torque control.
   - ``ec``: toggle cogging torque compensation.
-  - ``e``: and any command starting with e like ep, ev, et will disable the motorcontrol. It's the same as the command [enter].
+  - ``e``: and any command starting with e like ep, ev, et will disable the torque controller. It's the same as the command [enter].
   - ``z``: reset the multiturn position to 0 (the number of turn). This doesn't change the offset. This command only works with the REM 16MT position sensor.
   - ``zz``: reset the multiturn and singleturn position to 0. The offset need to be found again. This command only works with the REM 16MT position sensor.
   - ``o[number]``: set the commutation offset. The range is [0 - 4095].
@@ -115,7 +115,7 @@ The number can be negative. Spaces are ignored. The default number value is 0.
   - ``d``: toggle the motion polarity. It reverse the position/velocity/torque commands and feedback in the motion controller. Which will make you motor turn the other direction.
   - ``m``: toggle the phase inverted parameter. Use this if after finding the offset you have a positive torque resulting in a negative velocity.
   - ``P[number]``: set the pole pairs. If when using torque control and the motor moves a little bit then "hold" a position it can be because the pole pairs are incorrect. (it can also be caused by the position sensor).
-  - ``f``: reset the motorcontrol fault. If the motor stops because of over/under current. Try adjusting you power supply settings and maybe set a lower maximum torque.
+  - ``f``: reset the torque control fault. If the motor stops because of over/under current. Try adjusting you power supply settings and maybe set a lower maximum torque.
   - ``g[number]``: set the GPIO output. The number to input must be four ``0`` or ``1``. GPIO port 1 is the rightmost bit.
   - ``tss``: set the torque safe mode. in this mode all the phases are disconnected and the motor is free to move. Use this if you want to manually move the axis.
   - ``kpp [number]``: set the P coefficient of the Position controller.
@@ -130,10 +130,10 @@ The number can be negative. Spaces are ignored. The default number value is 0.
   - ``kpl [number]``: set the Integral part limit the Velocity controller.
   - ``ktr [number]``: set the rated torque.
   - ``kf [number]``: set the cut-off frequency of the filter in motion control service in Hz (0 to disable)
-  - ``Lp [number]``:  set both the maximum and minimum position limit to [number] and -[number]. The motorcontrol will be automatically disable when the position limit is reached. You can use this feature if your axis has a limited movement. If you are past the limits move the axis manually (use b and tss to unlock the motor) or restart position/velocity/torque controller in the right direction (the position limiter has a threshold to allow to restart if the motor is right after the limit).
+  - ``Lp [number]``:  set both the maximum and minimum position limit to [number] and -[number]. The torque controller will be automatically disable when the position limit is reached. You can use this feature if your axis has a limited movement. If you are past the limits move the axis manually (use b and tss to unlock the motor) or restart position/velocity/torque controller in the right direction (the position limiter has a threshold to allow to restart if the motor is right after the limit).
   - ``Lpu [number]``: set the maximum position limit.
   - ``Lpl [number]``: set the minimum position limit.
-  - ``Lt [number]``: set the torque limit. The unit in in 1/1000 of rated torque. This command stops the motorcontrol.
+  - ``Lt [number]``: set the torque limit. The unit in in 1/1000 of rated torque. This command stops the torque controller.
   - ``Lv [number]``: set the velocity limit. Used in velocity control and in cascaded and limited-torque position control modes.
   - ``[number]``: just entering a number will switch to torque control mode and set a target torque.
 
@@ -165,7 +165,7 @@ When the application has been compiled, the next step is to run it on the Linux 
 
        bin/app_demo_master_ethercat_tuning -o -n 0
 
-   #. The application will display the actual position, velocity and torque of the selected slave. It also displays some other parameters or status such as the commutation offset, the brake and motorcontrol status, the PID parameters, etc. If there is an error with the motorcontrol, motion control or position sensor it will be displayed on the last line::
+   #. The application will display the actual position, velocity and torque of the selected slave. It also displays some other parameters or status such as the commutation offset, the brake and motorcontrol status, the PID parameters, etc. If there is an error with the torque controller, motion control or position sensor it will be displayed on the last line::
 
         ** Operation mode: off **
         Position         122776 | Velocity               0

--- a/examples/app_demo_master_ethercat_tuning/src/display.c
+++ b/examples/app_demo_master_ethercat_tuning/src/display.c
@@ -209,7 +209,7 @@ int display_tuning(WINDOW *wnd, struct _pdo_cia402_output pdo_output, struct _pd
     }
     //row 16
     wmoveclr(wnd, &row);
-    //motorcontrol fault
+    //torque controller fault
     if (input.error_status != 0) {
         wprintw(wnd, "* Motor Fault ");
         print_motor_fault(wnd, input.error_status);

--- a/examples/app_demo_master_ethercat_tuning/src/tuning.c
+++ b/examples/app_demo_master_ethercat_tuning/src/tuning.c
@@ -203,7 +203,7 @@ void tuning_command(WINDOW *wnd, struct _pdo_cia402_output *pdo_output, struct _
             output->value *= output->sign;
             switch(output->mode_1) {
 
-            // enable/disable motorcontrol commands
+            // offset finding, position/velocity control auto tune, and cogging torque commands
             case 'a':
                 pdo_output->tuning_command = TUNING_CMD_AUTO_OFFSET;
                 switch(output->mode_2) {

--- a/examples/app_demo_slave_ethercat_motorcontrol/config.xscope
+++ b/examples/app_demo_slave_ethercat_motorcontrol/config.xscope
@@ -19,13 +19,8 @@
     <!-- For example: -->
     <!-- <Probe name="Probe Name" type="CONTINUOUS" datatype="UINT" units="Value" enabled="true"/> -->
     <!-- From the target code, call: xscope_int(PROBE_NAME, value); -->
-    <Probe name="target torque" type="CONTINUOUS" datatype="INT" units="Value" enabled="false"/>
-    <Probe name="actual torque" type="CONTINUOUS" datatype="INT" units="Value" enabled="false"/>
-    <Probe name="Phase B" type="CONTINUOUS" datatype="INT" units="Value" enabled="false"/>
-    <Probe name="Phase C" type="CONTINUOUS" datatype="INT" units="Value" enabled="false"/>
-
-    <Probe name="actual position" type="CONTINUOUS" datatype="INT" units="Value" enabled="true"/>
-    <Probe name="target position" type="CONTINUOUS" datatype="INT" units="Value" enabled="true"/>
-    <Probe name="famous fault" type="CONTINUOUS" datatype="INT" units="Value" enabled="true"/>
-
+    <Probe name="actual position" type="CONTINUOUS" datatype="INT" units="Value" enabled="false"/>
+    <Probe name="target position" type="CONTINUOUS" datatype="INT" units="Value" enabled="false"/>
+    <Probe name="actual velocity" type="CONTINUOUS" datatype="INT" units="Value" enabled="false"/>
+    
 </xSCOPEconfig>

--- a/examples/app_demo_slave_ethercat_motorcontrol/src/main.xc
+++ b/examples/app_demo_slave_ethercat_motorcontrol/src/main.xc
@@ -101,10 +101,8 @@ int main(void)
 
                 {
                     network_drive_service(
-                            i_pdo,
-                            i_co[1],
-                            i_torque_control[1],
-                            i_motion_control[0], i_position_feedback_1[0], i_position_feedback_2[0], i_file_service[1]);
+                            i_pdo, i_co[1], i_motion_control[0],
+                            i_position_feedback_1[0], i_position_feedback_2[0], i_file_service[1]);
                 }
 
             }

--- a/examples/app_demo_slave_ethercat_motorcontrol/src/main.xc
+++ b/examples/app_demo_slave_ethercat_motorcontrol/src/main.xc
@@ -10,7 +10,7 @@
  * @author Synapticon GmbH (www.synapticon.com)
  */
 
-// Please configure your slave's default motorcontrol parameters in config_motor_slave/user_config.h.
+// Please configure your slave's default parameters in config_motor_slave/user_config.h.
 // These parameter will be eventually overwritten by the app running on the EtherCAT master
 #include <user_config.h>
 
@@ -202,38 +202,38 @@ int main(void)
                     watchdog_service(wd_ports, i_watchdog, IFM_TILE_USEC);
                 }
 
-                /* Motor Control Service */
+                /* Torque Control Service */
                 {
-                    MotorcontrolConfig motorcontrol_config;
+                    MotorcontrolConfig torque_control_config;
 
-                    motorcontrol_config.dc_bus_voltage =  DC_BUS_VOLTAGE;
-                    motorcontrol_config.phases_inverted = MOTOR_PHASES_CONFIGURATION;
-                    motorcontrol_config.torque_P_gain =  TORQUE_Kp;
-                    motorcontrol_config.torque_I_gain =  TORQUE_Ki;
-                    motorcontrol_config.torque_D_gain =  TORQUE_Kd;
-                    motorcontrol_config.pole_pairs =  MOTOR_POLE_PAIRS;
-                    motorcontrol_config.commutation_sensor=SENSOR_1_TYPE;
-                    motorcontrol_config.commutation_angle_offset=COMMUTATION_ANGLE_OFFSET;
-                    motorcontrol_config.max_torque =  MOTOR_MAXIMUM_TORQUE;
-                    motorcontrol_config.phase_resistance =  MOTOR_PHASE_RESISTANCE;
-                    motorcontrol_config.phase_inductance =  MOTOR_PHASE_INDUCTANCE;
-                    motorcontrol_config.torque_constant =  MOTOR_TORQUE_CONSTANT;
-                    motorcontrol_config.current_ratio =  CURRENT_RATIO;
-                    motorcontrol_config.voltage_ratio =  VOLTAGE_RATIO;
-                    motorcontrol_config.temperature_ratio =  TEMPERATURE_RATIO;
-                    motorcontrol_config.rated_current =  MOTOR_RATED_CURRENT;
-                    motorcontrol_config.rated_torque  =  MOTOR_RATED_TORQUE;
-                    motorcontrol_config.percent_offset_torque =  APPLIED_TUNING_TORQUE_PERCENT;
-                    motorcontrol_config.protection_limit_over_current =  PROTECTION_MAXIMUM_CURRENT;
-                    motorcontrol_config.protection_limit_over_voltage =  PROTECTION_MAXIMUM_VOLTAGE;
-                    motorcontrol_config.protection_limit_under_voltage = PROTECTION_MINIMUM_VOLTAGE;
-                    motorcontrol_config.protection_limit_over_temperature = TEMP_BOARD_MAX;
+                    torque_control_config.dc_bus_voltage =  DC_BUS_VOLTAGE;
+                    torque_control_config.phases_inverted = MOTOR_PHASES_CONFIGURATION;
+                    torque_control_config.torque_P_gain =  TORQUE_Kp;
+                    torque_control_config.torque_I_gain =  TORQUE_Ki;
+                    torque_control_config.torque_D_gain =  TORQUE_Kd;
+                    torque_control_config.pole_pairs =  MOTOR_POLE_PAIRS;
+                    torque_control_config.commutation_sensor=SENSOR_1_TYPE;
+                    torque_control_config.commutation_angle_offset=COMMUTATION_ANGLE_OFFSET;
+                    torque_control_config.max_torque =  MOTOR_MAXIMUM_TORQUE;
+                    torque_control_config.phase_resistance =  MOTOR_PHASE_RESISTANCE;
+                    torque_control_config.phase_inductance =  MOTOR_PHASE_INDUCTANCE;
+                    torque_control_config.torque_constant =  MOTOR_TORQUE_CONSTANT;
+                    torque_control_config.current_ratio =  CURRENT_RATIO;
+                    torque_control_config.voltage_ratio =  VOLTAGE_RATIO;
+                    torque_control_config.temperature_ratio =  TEMPERATURE_RATIO;
+                    torque_control_config.rated_current =  MOTOR_RATED_CURRENT;
+                    torque_control_config.rated_torque  =  MOTOR_RATED_TORQUE;
+                    torque_control_config.percent_offset_torque =  APPLIED_TUNING_TORQUE_PERCENT;
+                    torque_control_config.protection_limit_over_current =  PROTECTION_MAXIMUM_CURRENT;
+                    torque_control_config.protection_limit_over_voltage =  PROTECTION_MAXIMUM_VOLTAGE;
+                    torque_control_config.protection_limit_under_voltage = PROTECTION_MINIMUM_VOLTAGE;
+                    torque_control_config.protection_limit_over_temperature = TEMP_BOARD_MAX;
 
                     for (int i = 0; i < 1024; i++)
                     {
-                        motorcontrol_config.torque_offset[i] = 0;
+                        torque_control_config.torque_offset[i] = 0;
                     }
-                    torque_control_service(motorcontrol_config, i_adc[0], i_shared_memory[2],
+                    torque_control_service(torque_control_config, i_adc[0], i_shared_memory[2],
                             i_watchdog[0], i_torque_control, i_update_pwm, IFM_TILE_USEC, /*gpio_port_0*/null);
                 }
 

--- a/module_canopen_interface/doc/index.rst
+++ b/module_canopen_interface/doc/index.rst
@@ -87,7 +87,7 @@ How to use CANopen Interface Service
             interface update_pwm i_update_pwm;
             interface update_brake i_update_brake;
             interface ADCInterface i_adc[2];
-            interface MotorcontrolInterface i_motorcontrol[2];
+            interface MotorcontrolInterface i_torque_control[2];
             interface PositionVelocityCtrlInterface i_position_control[3];
             interface PositionFeedbackInterface i_position_feedback_1[3];
             interface PositionFeedbackInterface i_position_feedback_2[3];
@@ -152,12 +152,12 @@ How to use CANopen Interface Service
         
                             network_drive_service_debug( profiler_config,
                                                     i_co[1],
-                                                    i_motorcontrol[0],
+                                                    i_torque_control[0],
                                                     i_position_control[0], i_position_feedback_1[0]);
                 #else
                             network_drive_service( profiler_config,
                                                     i_co[1],
-                                                    i_motorcontrol[0],
+                                                    i_torque_control[0],
                                                     i_position_control[0], i_position_feedback_1[0], null);
                 #endif
                         }
@@ -211,7 +211,7 @@ How to use CANopen Interface Service
                             pos_velocity_ctrl_config.pull_brake_time =                      PULL_BRAKE_TIME;
                             pos_velocity_ctrl_config.hold_brake_voltage =                   HOLD_BRAKE_VOLTAGE;
         
-                             motion_control_service(APP_TILE_USEC, pos_velocity_ctrl_config, i_motorcontrol[1], 
+                             motion_control_service(APP_TILE_USEC, pos_velocity_ctrl_config, i_torque_control[1], 
                              i_position_control, i_update_brake);
                         }
                     }
@@ -249,37 +249,37 @@ How to use CANopen Interface Service
         
                         /* Motor Control Service */
                         {
-                            MotorcontrolConfig motorcontrol_config;
+                            MotorcontrolConfig torque_control_config;
         
-                            motorcontrol_config.v_dc =  DC_BUS_VOLTAGE;
-                            motorcontrol_config.phases_inverted = MOTOR_PHASES_NORMAL;
-                            motorcontrol_config.torque_P_gain =  TORQUE_P_VALUE;
-                            motorcontrol_config.torque_I_gain =  TORQUE_I_VALUE;
-                            motorcontrol_config.torque_D_gain =  TORQUE_D_VALUE;
-                            motorcontrol_config.pole_pairs =  MOTOR_POLE_PAIRS;
-                            motorcontrol_config.commutation_sensor=SENSOR_1_TYPE;
-                            motorcontrol_config.commutation_angle_offset=COMMUTATION_ANGLE_OFFSET;
-                            motorcontrol_config.hall_state_angle[0]=HALL_STATE_1_ANGLE;
-                            motorcontrol_config.hall_state_angle[1]=HALL_STATE_2_ANGLE;
-                            motorcontrol_config.hall_state_angle[2]=HALL_STATE_3_ANGLE;
-                            motorcontrol_config.hall_state_angle[3]=HALL_STATE_4_ANGLE;
-                            motorcontrol_config.hall_state_angle[4]=HALL_STATE_5_ANGLE;
-                            motorcontrol_config.hall_state_angle[5]=HALL_STATE_6_ANGLE;
-                            motorcontrol_config.max_torque =  MOTOR_MAXIMUM_TORQUE;
-                            motorcontrol_config.phase_resistance =  MOTOR_PHASE_RESISTANCE;
-                            motorcontrol_config.phase_inductance =  MOTOR_PHASE_INDUCTANCE;
-                            motorcontrol_config.torque_constant =  MOTOR_TORQUE_CONSTANT;
-                            motorcontrol_config.current_ratio =  CURRENT_RATIO;
-                            motorcontrol_config.voltage_ratio =  VOLTAGE_RATIO;
-                            motorcontrol_config.rated_current =  MOTOR_RATED_CURRENT;
-                            motorcontrol_config.rated_torque  =  MOTOR_RATED_TORQUE;
-                            motorcontrol_config.percent_offset_torque =  APPLIED_TUNING_TORQUE_PERCENT;
-                            motorcontrol_config.protection_limit_over_current =  PROTECTION_MAXIMUM_CURRENT;
-                            motorcontrol_config.protection_limit_over_voltage =  PROTECTION_MAXIMUM_VOLTAGE;
-                            motorcontrol_config.protection_limit_under_voltage = PROTECTION_MINIMUM_VOLTAGE;
+                            torque_control_config.v_dc =  DC_BUS_VOLTAGE;
+                            torque_control_config.phases_inverted = MOTOR_PHASES_NORMAL;
+                            torque_control_config.torque_P_gain =  TORQUE_P_VALUE;
+                            torque_control_config.torque_I_gain =  TORQUE_I_VALUE;
+                            torque_control_config.torque_D_gain =  TORQUE_D_VALUE;
+                            torque_control_config.pole_pairs =  MOTOR_POLE_PAIRS;
+                            torque_control_config.commutation_sensor=SENSOR_1_TYPE;
+                            torque_control_config.commutation_angle_offset=COMMUTATION_ANGLE_OFFSET;
+                            torque_control_config.hall_state_angle[0]=HALL_STATE_1_ANGLE;
+                            torque_control_config.hall_state_angle[1]=HALL_STATE_2_ANGLE;
+                            torque_control_config.hall_state_angle[2]=HALL_STATE_3_ANGLE;
+                            torque_control_config.hall_state_angle[3]=HALL_STATE_4_ANGLE;
+                            torque_control_config.hall_state_angle[4]=HALL_STATE_5_ANGLE;
+                            torque_control_config.hall_state_angle[5]=HALL_STATE_6_ANGLE;
+                            torque_control_config.max_torque =  MOTOR_MAXIMUM_TORQUE;
+                            torque_control_config.phase_resistance =  MOTOR_PHASE_RESISTANCE;
+                            torque_control_config.phase_inductance =  MOTOR_PHASE_INDUCTANCE;
+                            torque_control_config.torque_constant =  MOTOR_TORQUE_CONSTANT;
+                            torque_control_config.current_ratio =  CURRENT_RATIO;
+                            torque_control_config.voltage_ratio =  VOLTAGE_RATIO;
+                            torque_control_config.rated_current =  MOTOR_RATED_CURRENT;
+                            torque_control_config.rated_torque  =  MOTOR_RATED_TORQUE;
+                            torque_control_config.percent_offset_torque =  APPLIED_TUNING_TORQUE_PERCENT;
+                            torque_control_config.protection_limit_over_current =  PROTECTION_MAXIMUM_CURRENT;
+                            torque_control_config.protection_limit_over_voltage =  PROTECTION_MAXIMUM_VOLTAGE;
+                            torque_control_config.protection_limit_under_voltage = PROTECTION_MINIMUM_VOLTAGE;
         
-                            motor_control_service(motorcontrol_config, i_adc[0], i_shared_memory[2],
-                                    i_watchdog[0], i_motorcontrol, i_update_pwm, IFM_TILE_USEC);
+                            motor_control_service(torque_control_config, i_adc[0], i_shared_memory[2],
+                                    i_watchdog[0], i_torque_control, i_update_pwm, IFM_TILE_USEC);
                         }
         
                         /* Shared memory Service */

--- a/module_network_drive/include/config_manager.h
+++ b/module_network_drive/include/config_manager.h
@@ -49,7 +49,7 @@ int cm_sync_config_position_feedback(
 
 int cm_sync_config_motor_control(
         client interface i_co_communication i_co,
-        client interface TorqueControlInterface ?i_torque_control,
+        client interface MotionControlInterface i_motion_control,
         MotorcontrolConfig &commutation_params,
         int sensor_commutation_type);
 
@@ -59,15 +59,6 @@ void cm_sync_config_pos_velocity_control(
         MotionControlConfig &position_config,
         int sensor_resolution,
         int max_torque);
-
-/* This function is a workaround until the hall and motorconfig is reorganized. */
-void cm_sync_config_hall_states(
-        client interface i_co_communication i_co,
-        client interface PositionFeedbackInterface i_pos_feedback,
-        client interface TorqueControlInterface ?i_torque_control,
-        PositionFeedbackConfig &feedback_config,
-        MotorcontrolConfig &motorcontrol_config,
-        int sensor_index);
 
 /*
  * Set default configuration of the modules in the object dictionary. If nothing
@@ -82,7 +73,7 @@ void cm_default_config_position_feedback(
 
 void cm_default_config_motor_control(
         client interface i_co_communication i_co,
-        client interface TorqueControlInterface ?i_torque_control,
+        client interface MotionControlInterface i_motion_control,
         MotorcontrolConfig &commutation_params);
 
 void cm_default_config_pos_velocity_control(

--- a/module_network_drive/include/network_drive_service.h
+++ b/module_network_drive/include/network_drive_service.h
@@ -27,14 +27,12 @@
  *
  * @param i_pdo Interface for PDOs to communication module.
  * @param i_od Interface for SDOs to CANopen service.
- * @param i_torque_control Interface to Motor Control Service
  * @param i_motion_control Interface to Motion Control Service.
  * @param i_position_feedback_1 Interface to the fisrt sensor service
  * @param i_position_feedback_2 Interface to the second sensor service
  */
 void network_drive_service( client interface i_pdo_handler_exchange i_pdo,
                             client interface i_co_communication i_co,
-                            client interface TorqueControlInterface i_torque_control,
                             client interface MotionControlInterface i_motion_control,
                             client interface PositionFeedbackInterface i_position_feedback_1,
                             client interface PositionFeedbackInterface ?i_position_feedback_2,

--- a/module_network_drive/include/tuning.h
+++ b/module_network_drive/include/tuning.h
@@ -154,7 +154,7 @@ typedef struct {
  * @param user_miso to send multiple parameters and status to the master
  * @param tuning_status to send multiple parameters and status to the master
  * @param tuning_mode_state state of the motorcontrol in tuning mode
- * @param motorcontrol_config configuration structure of the motorcontrol service
+ * @param torque_control_config configuration structure of the torque control service
  * @param motion_ctrl_config configuration structure of the motion control service
  * @param pos_feedback_config_1 configuration structure of the position feedback number 1
  * @param pos_feedback_config_2 configuration structure of the position feedback number 2
@@ -169,7 +169,7 @@ int tuning_handler_ethercat(
         /* input */  uint32_t    tuning_command,
         /* output */ uint32_t    &user_miso, uint32_t &tuning_status,
         TuningModeState             &tuning_mode_state,
-        MotorcontrolConfig       &motorcontrol_config,
+        MotorcontrolConfig       &torque_control_config,
         MotionControlConfig &motion_ctrl_config,
         PositionFeedbackConfig   &pos_feedback_config_1,
         PositionFeedbackConfig   &pos_feedback_config_2,
@@ -187,7 +187,7 @@ int tuning_handler_ethercat(
  * @brief Function to handle the tuning commands
  *
  * @param tuning_mode_state state of the motorcontrol in tuning mode, also contains the tuning command and value
- * @param motorcontrol_config configuration structure of the motorcontrol service
+ * @param torque_control_config configuration structure of the torque control service
  * @param motion_ctrl_config configuration structure of the motion control service
  * @param pos_feedback_config_1 configuration structure of the position feedback number 1
  * @param pos_feedback_config_2 configuration structure of the position feedback number 2
@@ -200,7 +200,7 @@ int tuning_handler_ethercat(
  */
 void tuning_command_handler(
         TuningModeState             &tuning_mode_state,
-        MotorcontrolConfig       &motorcontrol_config,
+        MotorcontrolConfig       &torque_control_config,
         MotionControlConfig &motion_ctrl_config,
         PositionFeedbackConfig   &pos_feedback_config_1,
         PositionFeedbackConfig   &pos_feedback_config_2,
@@ -216,14 +216,14 @@ void tuning_command_handler(
 /**
  * @brief Function to parse different status flags to send to the master
  *
- * @param motorcontrol_config configuration structure of the motorcontrol service
+ * @param torque_control_config configuration structure of the torque control service
  * @param motion_ctrl_config configuration structure of the motion control service
  * @param pos_feedback_config_1 configuration structure of the position feedback number 1
  * @param pos_feedback_config_2 configuration structure of the position feedback number 2
  * @param sensor_commutation number of the commutation sensor
  */
 uint8_t tuning_set_flags(TuningModeState &tuning_mode_state,
-        MotorcontrolConfig       &motorcontrol_config,
+        MotorcontrolConfig       &torque_control_config,
         MotionControlConfig      &motion_ctrl_config,
         PositionFeedbackConfig   &pos_feedback_config_1,
         PositionFeedbackConfig   &pos_feedback_config_2,

--- a/module_network_drive/src/config_manager.xc
+++ b/module_network_drive/src/config_manager.xc
@@ -163,14 +163,11 @@ int cm_sync_config_position_feedback(
 
 int cm_sync_config_motor_control(
         client interface i_co_communication i_co,
-        interface TorqueControlInterface client ?i_torque_control,
+        client interface MotionControlInterface i_motion_control,
         MotorcontrolConfig &motorcontrol_config,
         int sensor_commutation_type)
 {
-    if (isnull(i_torque_control))
-        return motorcontrol_config.max_torque;
-
-    motorcontrol_config = i_torque_control.get_config();
+    motorcontrol_config = i_motion_control.get_motorcontrol_config();
 
     //convert float values
     union sdo_value temp;
@@ -204,7 +201,7 @@ int cm_sync_config_motor_control(
     {motorcontrol_config.protection_limit_over_voltage, void, void} = i_co.od_get_object_value(DICT_PROTECTION, SUB_PROTECTION_MAX_DC_VOLTAGE);
     //FIXME: missing motorcontrol_config.protection_limit_over_temperature
 
-    i_torque_control.set_config(motorcontrol_config);
+    i_motion_control.set_motorcontrol_config(motorcontrol_config);
 
     return motorcontrol_config.max_torque;
 }
@@ -382,14 +379,11 @@ void cm_default_config_position_feedback(
 
 void cm_default_config_motor_control(
         client interface i_co_communication i_co,
-        interface TorqueControlInterface client ?i_torque_control,
+        client interface MotionControlInterface i_motion_control,
         MotorcontrolConfig &motorcontrol_config)
 
 {
-    if (isnull(i_torque_control))
-        return;
-
-    motorcontrol_config = i_torque_control.get_config();
+    motorcontrol_config = i_motion_control.get_motorcontrol_config();
 
     //convert float values
     union sdo_value value;

--- a/module_network_drive/src/config_manager.xc
+++ b/module_network_drive/src/config_manager.xc
@@ -164,46 +164,46 @@ int cm_sync_config_position_feedback(
 int cm_sync_config_motor_control(
         client interface i_co_communication i_co,
         client interface MotionControlInterface i_motion_control,
-        MotorcontrolConfig &motorcontrol_config,
+        MotorcontrolConfig &torque_control_config,
         int sensor_commutation_type)
 {
-    motorcontrol_config = i_motion_control.get_motorcontrol_config();
+    torque_control_config = i_motion_control.get_motorcontrol_config();
 
     //convert float values
     union sdo_value temp;
     {temp.i, void, void} = i_co.od_get_object_value(DICT_TORQUE_CONTROLLER, SUB_TORQUE_CONTROLLER_CONTROLLER_KP);
-    motorcontrol_config.torque_P_gain = (int)temp.f;
+    torque_control_config.torque_P_gain = (int)temp.f;
     {temp.i, void, void} = i_co.od_get_object_value(DICT_TORQUE_CONTROLLER, SUB_TORQUE_CONTROLLER_CONTROLLER_KI);
-    motorcontrol_config.torque_I_gain = (int)temp.f;
+    torque_control_config.torque_I_gain = (int)temp.f;
     {temp.i, void, void} = i_co.od_get_object_value(DICT_TORQUE_CONTROLLER, SUB_TORQUE_CONTROLLER_CONTROLLER_KD);
-    motorcontrol_config.torque_D_gain = (int)temp.f;
+    torque_control_config.torque_D_gain = (int)temp.f;
 
-    {motorcontrol_config.dc_bus_voltage, void, void} = i_co.od_get_object_value(DICT_BREAK_RELEASE, SUB_BREAK_RELEASE_DC_BUS_VOLTAGE);
-    {motorcontrol_config.phases_inverted, void, void} = i_co.od_get_object_value(DICT_MOTOR_SPECIFIC_SETTINGS, SUB_MOTOR_SPECIFIC_SETTINGS_MOTOR_PHASES_INVERTED);
-    {motorcontrol_config.pole_pairs, void, void} = i_co.od_get_object_value(DICT_MOTOR_SPECIFIC_SETTINGS, SUB_MOTOR_SPECIFIC_SETTINGS_POLE_PAIRS);
-    motorcontrol_config.commutation_sensor       = sensor_commutation_type;
-    {motorcontrol_config.commutation_angle_offset, void, void} = i_co.od_get_object_value(DICT_COMMUTATION_ANGLE_OFFSET, 0);
-    {motorcontrol_config.rated_torque, void, void} = i_co.od_get_object_value(DICT_MOTOR_RATED_TORQUE, 0);
-    if (motorcontrol_config.rated_torque == 0) {
-        motorcontrol_config.rated_torque = 1;
+    {torque_control_config.dc_bus_voltage, void, void} = i_co.od_get_object_value(DICT_BREAK_RELEASE, SUB_BREAK_RELEASE_DC_BUS_VOLTAGE);
+    {torque_control_config.phases_inverted, void, void} = i_co.od_get_object_value(DICT_MOTOR_SPECIFIC_SETTINGS, SUB_MOTOR_SPECIFIC_SETTINGS_MOTOR_PHASES_INVERTED);
+    {torque_control_config.pole_pairs, void, void} = i_co.od_get_object_value(DICT_MOTOR_SPECIFIC_SETTINGS, SUB_MOTOR_SPECIFIC_SETTINGS_POLE_PAIRS);
+    torque_control_config.commutation_sensor       = sensor_commutation_type;
+    {torque_control_config.commutation_angle_offset, void, void} = i_co.od_get_object_value(DICT_COMMUTATION_ANGLE_OFFSET, 0);
+    {torque_control_config.rated_torque, void, void} = i_co.od_get_object_value(DICT_MOTOR_RATED_TORQUE, 0);
+    if (torque_control_config.rated_torque == 0) {
+        torque_control_config.rated_torque = 1;
     }
     int tmp = 0;
     {tmp, void, void} = i_co.od_get_object_value(DICT_MAX_TORQUE, 0);
-    motorcontrol_config.max_torque = (tmp  * motorcontrol_config.rated_torque) / 1000; // in 1/1000 of rated torque;
-    {motorcontrol_config.phase_resistance, void, void} = i_co.od_get_object_value(DICT_MOTOR_SPECIFIC_SETTINGS, SUB_MOTOR_SPECIFIC_SETTINGS_PHASE_RESISTANCE);
-    {motorcontrol_config.phase_inductance, void, void} = i_co.od_get_object_value(DICT_MOTOR_SPECIFIC_SETTINGS, SUB_MOTOR_SPECIFIC_SETTINGS_PHASE_INDUCTANCE);
-    {motorcontrol_config.torque_constant, void, void} = i_co.od_get_object_value(DICT_MOTOR_SPECIFIC_SETTINGS, SUB_MOTOR_SPECIFIC_SETTINGS_TORQUE_CONSTANT);
-    {motorcontrol_config.rated_current, void, void} = i_co.od_get_object_value(DICT_MOTOR_RATED_CURRENT, 0);
-    {motorcontrol_config.percent_offset_torque, void, void} = i_co.od_get_object_value(DICT_APPLIED_TUNING_TORQUE_PERCENT, 0);
+    torque_control_config.max_torque = (tmp  * torque_control_config.rated_torque) / 1000; // in 1/1000 of rated torque;
+    {torque_control_config.phase_resistance, void, void} = i_co.od_get_object_value(DICT_MOTOR_SPECIFIC_SETTINGS, SUB_MOTOR_SPECIFIC_SETTINGS_PHASE_RESISTANCE);
+    {torque_control_config.phase_inductance, void, void} = i_co.od_get_object_value(DICT_MOTOR_SPECIFIC_SETTINGS, SUB_MOTOR_SPECIFIC_SETTINGS_PHASE_INDUCTANCE);
+    {torque_control_config.torque_constant, void, void} = i_co.od_get_object_value(DICT_MOTOR_SPECIFIC_SETTINGS, SUB_MOTOR_SPECIFIC_SETTINGS_TORQUE_CONSTANT);
+    {torque_control_config.rated_current, void, void} = i_co.od_get_object_value(DICT_MOTOR_RATED_CURRENT, 0);
+    {torque_control_config.percent_offset_torque, void, void} = i_co.od_get_object_value(DICT_APPLIED_TUNING_TORQUE_PERCENT, 0);
     /* Read protection limits */
-    {motorcontrol_config.protection_limit_over_current, void, void} = i_co.od_get_object_value(DICT_PROTECTION, SUB_PROTECTION_MAX_CURRENT);
-    {motorcontrol_config.protection_limit_under_voltage, void, void} = i_co.od_get_object_value(DICT_PROTECTION, SUB_PROTECTION_MIN_DC_VOLTAGE);
-    {motorcontrol_config.protection_limit_over_voltage, void, void} = i_co.od_get_object_value(DICT_PROTECTION, SUB_PROTECTION_MAX_DC_VOLTAGE);
-    //FIXME: missing motorcontrol_config.protection_limit_over_temperature
+    {torque_control_config.protection_limit_over_current, void, void} = i_co.od_get_object_value(DICT_PROTECTION, SUB_PROTECTION_MAX_CURRENT);
+    {torque_control_config.protection_limit_under_voltage, void, void} = i_co.od_get_object_value(DICT_PROTECTION, SUB_PROTECTION_MIN_DC_VOLTAGE);
+    {torque_control_config.protection_limit_over_voltage, void, void} = i_co.od_get_object_value(DICT_PROTECTION, SUB_PROTECTION_MAX_DC_VOLTAGE);
+    //FIXME: missing torque_control_config.protection_limit_over_temperature
 
-    i_motion_control.set_motorcontrol_config(motorcontrol_config);
+    i_motion_control.set_motorcontrol_config(torque_control_config);
 
-    return motorcontrol_config.max_torque;
+    return torque_control_config.max_torque;
 }
 
 void cm_sync_config_pos_velocity_control(
@@ -380,37 +380,37 @@ void cm_default_config_position_feedback(
 void cm_default_config_motor_control(
         client interface i_co_communication i_co,
         client interface MotionControlInterface i_motion_control,
-        MotorcontrolConfig &motorcontrol_config)
+        MotorcontrolConfig &torque_control_config)
 
 {
-    motorcontrol_config = i_motion_control.get_motorcontrol_config();
+    torque_control_config = i_motion_control.get_motorcontrol_config();
 
     //convert float values
     union sdo_value value;
-    value.f = (float)motorcontrol_config.torque_P_gain;
+    value.f = (float)torque_control_config.torque_P_gain;
     i_co.od_set_object_value(DICT_TORQUE_CONTROLLER, SUB_TORQUE_CONTROLLER_CONTROLLER_KP, value.i);
-    value.f = (float)motorcontrol_config.torque_I_gain;
+    value.f = (float)torque_control_config.torque_I_gain;
     i_co.od_set_object_value(DICT_TORQUE_CONTROLLER, SUB_TORQUE_CONTROLLER_CONTROLLER_KI, value.i);
-    value.f = (float)motorcontrol_config.torque_D_gain;
+    value.f = (float)torque_control_config.torque_D_gain;
     i_co.od_set_object_value(DICT_TORQUE_CONTROLLER, SUB_TORQUE_CONTROLLER_CONTROLLER_KD, value.i);
 
-    i_co.od_set_object_value(DICT_BREAK_RELEASE, SUB_BREAK_RELEASE_DC_BUS_VOLTAGE, motorcontrol_config.dc_bus_voltage);
-    i_co.od_set_object_value(DICT_MOTOR_SPECIFIC_SETTINGS, SUB_MOTOR_SPECIFIC_SETTINGS_MOTOR_PHASES_INVERTED, motorcontrol_config.phases_inverted);
-    i_co.od_set_object_value(DICT_MOTOR_SPECIFIC_SETTINGS, SUB_MOTOR_SPECIFIC_SETTINGS_POLE_PAIRS, motorcontrol_config.pole_pairs);
-    i_co.od_set_object_value(DICT_COMMUTATION_ANGLE_OFFSET, 0, motorcontrol_config.commutation_angle_offset);
-    i_co.od_set_object_value(DICT_MOTOR_SPECIFIC_SETTINGS, SUB_MOTOR_SPECIFIC_SETTINGS_PHASE_RESISTANCE, motorcontrol_config.phase_resistance);
-    i_co.od_set_object_value(DICT_MOTOR_SPECIFIC_SETTINGS, SUB_MOTOR_SPECIFIC_SETTINGS_PHASE_INDUCTANCE, motorcontrol_config.phase_inductance);
-    i_co.od_set_object_value(DICT_MOTOR_SPECIFIC_SETTINGS, SUB_MOTOR_SPECIFIC_SETTINGS_TORQUE_CONSTANT, motorcontrol_config.torque_constant);
-    i_co.od_set_object_value(DICT_MOTOR_RATED_CURRENT, 0, motorcontrol_config.rated_current);
-    i_co.od_set_object_value(DICT_MOTOR_RATED_TORQUE, 0, motorcontrol_config.rated_torque);
-    i_co.od_set_object_value(DICT_MAX_TORQUE, 0, (motorcontrol_config.max_torque * 1000) / motorcontrol_config.rated_torque); // in 1/1000 of rated torque
-    i_co.od_set_object_value(DICT_APPLIED_TUNING_TORQUE_PERCENT, 0, motorcontrol_config.percent_offset_torque);
+    i_co.od_set_object_value(DICT_BREAK_RELEASE, SUB_BREAK_RELEASE_DC_BUS_VOLTAGE, torque_control_config.dc_bus_voltage);
+    i_co.od_set_object_value(DICT_MOTOR_SPECIFIC_SETTINGS, SUB_MOTOR_SPECIFIC_SETTINGS_MOTOR_PHASES_INVERTED, torque_control_config.phases_inverted);
+    i_co.od_set_object_value(DICT_MOTOR_SPECIFIC_SETTINGS, SUB_MOTOR_SPECIFIC_SETTINGS_POLE_PAIRS, torque_control_config.pole_pairs);
+    i_co.od_set_object_value(DICT_COMMUTATION_ANGLE_OFFSET, 0, torque_control_config.commutation_angle_offset);
+    i_co.od_set_object_value(DICT_MOTOR_SPECIFIC_SETTINGS, SUB_MOTOR_SPECIFIC_SETTINGS_PHASE_RESISTANCE, torque_control_config.phase_resistance);
+    i_co.od_set_object_value(DICT_MOTOR_SPECIFIC_SETTINGS, SUB_MOTOR_SPECIFIC_SETTINGS_PHASE_INDUCTANCE, torque_control_config.phase_inductance);
+    i_co.od_set_object_value(DICT_MOTOR_SPECIFIC_SETTINGS, SUB_MOTOR_SPECIFIC_SETTINGS_TORQUE_CONSTANT, torque_control_config.torque_constant);
+    i_co.od_set_object_value(DICT_MOTOR_RATED_CURRENT, 0, torque_control_config.rated_current);
+    i_co.od_set_object_value(DICT_MOTOR_RATED_TORQUE, 0, torque_control_config.rated_torque);
+    i_co.od_set_object_value(DICT_MAX_TORQUE, 0, (torque_control_config.max_torque * 1000) / torque_control_config.rated_torque); // in 1/1000 of rated torque
+    i_co.od_set_object_value(DICT_APPLIED_TUNING_TORQUE_PERCENT, 0, torque_control_config.percent_offset_torque);
     /* Write protection limits */
-    i_co.od_set_object_value(DICT_PROTECTION, SUB_PROTECTION_MAX_CURRENT, motorcontrol_config.protection_limit_over_current);
-    i_co.od_set_object_value(DICT_PROTECTION, SUB_PROTECTION_MIN_DC_VOLTAGE, motorcontrol_config.protection_limit_under_voltage);
-    i_co.od_set_object_value(DICT_PROTECTION, SUB_PROTECTION_MAX_DC_VOLTAGE, motorcontrol_config.protection_limit_over_voltage);
+    i_co.od_set_object_value(DICT_PROTECTION, SUB_PROTECTION_MAX_CURRENT, torque_control_config.protection_limit_over_current);
+    i_co.od_set_object_value(DICT_PROTECTION, SUB_PROTECTION_MIN_DC_VOLTAGE, torque_control_config.protection_limit_under_voltage);
+    i_co.od_set_object_value(DICT_PROTECTION, SUB_PROTECTION_MAX_DC_VOLTAGE, torque_control_config.protection_limit_over_voltage);
 
-    //FIXME: missing motorcontrol_config.protection_limit_over_temperature
+    //FIXME: missing torque_control_config.protection_limit_over_temperature
 }
 
 void cm_default_config_pos_velocity_control(

--- a/module_network_drive/src/tuning.xc
+++ b/module_network_drive/src/tuning.xc
@@ -24,7 +24,7 @@ int tuning_handler_ethercat(
         /* input */  uint32_t    tuning_command,
         /* output */ uint32_t    &user_miso, uint32_t &tuning_status,
         TuningModeState             &tuning_mode_state,
-        MotorcontrolConfig       &motorcontrol_config,
+        MotorcontrolConfig       &torque_control_config,
         MotionControlConfig &motion_ctrl_config,
         PositionFeedbackConfig   &pos_feedback_config_1,
         PositionFeedbackConfig   &pos_feedback_config_2,
@@ -48,10 +48,10 @@ int tuning_handler_ethercat(
     }
     switch(status_mux) {
     case TUNING_STATUS_MUX_OFFSET: //send offset
-        user_miso = motorcontrol_config.commutation_angle_offset;
+        user_miso = torque_control_config.commutation_angle_offset;
         break;
     case TUNING_STATUS_MUX_POLE_PAIRS: //pole pairs
-        user_miso = motorcontrol_config.pole_pairs;
+        user_miso = torque_control_config.pole_pairs;
         break;
     case TUNING_STATUS_MUX_MIN_POS: //position limit min
         user_miso = motion_ctrl_config.min_pos_range_limit;
@@ -63,7 +63,7 @@ int tuning_handler_ethercat(
         user_miso = motion_ctrl_config.max_motor_speed;
         break;
     case TUNING_STATUS_MUX_MAX_TORQUE: //max torque
-        user_miso = (motion_ctrl_config.max_torque*1000)/motorcontrol_config.rated_torque;
+        user_miso = (motion_ctrl_config.max_torque*1000)/torque_control_config.rated_torque;
         break;
     case TUNING_STATUS_MUX_POS_KP: //P_pos
         user_miso = motion_ctrl_config.position_kp;
@@ -102,7 +102,7 @@ int tuning_handler_ethercat(
         user_miso = upstream_control_data.motion_control_error;
         break;
     case TUNING_STATUS_MUX_RATED_TORQUE:// motion control error
-        user_miso = motorcontrol_config.rated_torque;
+        user_miso = torque_control_config.rated_torque;
         break;
     case TUNING_STATUS_MUX_FILTER:// filter
         user_miso = motion_ctrl_config.filter;
@@ -127,12 +127,12 @@ int tuning_handler_ethercat(
 
         //execute command
         tuning_command_handler(tuning_mode_state,
-                motorcontrol_config, motion_ctrl_config, pos_feedback_config_1, pos_feedback_config_2,
+                torque_control_config, motion_ctrl_config, pos_feedback_config_1, pos_feedback_config_2,
                 sensor_commutation, sensor_motion_control,
                 i_motion_control, i_position_feedback_1, i_position_feedback_2, i_file_service);
 
         //update flags
-        tuning_mode_state.flags = tuning_set_flags(tuning_mode_state, motorcontrol_config, motion_ctrl_config,
+        tuning_mode_state.flags = tuning_set_flags(tuning_mode_state, torque_control_config, motion_ctrl_config,
                 pos_feedback_config_1, pos_feedback_config_2, sensor_commutation);
     }
 
@@ -146,7 +146,7 @@ int tuning_handler_ethercat(
 
 void tuning_command_handler(
         TuningModeState             &tuning_mode_state,
-        MotorcontrolConfig       &motorcontrol_config,
+        MotorcontrolConfig       &torque_control_config,
         MotionControlConfig &motion_ctrl_config,
         PositionFeedbackConfig   &pos_feedback_config_1,
         PositionFeedbackConfig   &pos_feedback_config_2,
@@ -193,8 +193,8 @@ void tuning_command_handler(
             motion_ctrl_config.velocity_integral_limit = tuning_mode_state.value;
             break;
         case TUNING_CMD_MAX_TORQUE:
-            motion_ctrl_config.max_torque = (tuning_mode_state.value*motorcontrol_config.rated_torque)/1000;
-            motorcontrol_config.max_torque = motion_ctrl_config.max_torque;
+            motion_ctrl_config.max_torque = (tuning_mode_state.value*torque_control_config.rated_torque)/1000;
+            torque_control_config.max_torque = motion_ctrl_config.max_torque;
             break;
         case TUNING_CMD_MAX_SPEED:
             motion_ctrl_config.max_motor_speed = tuning_mode_state.value;
@@ -246,21 +246,21 @@ void tuning_command_handler(
                         i_position_feedback_1.set_config(pos_feedback_config_1);
                     }
                 }
-                motorcontrol_config.pole_pairs = tuning_mode_state.value;
+                torque_control_config.pole_pairs = tuning_mode_state.value;
             }
             break;
         case TUNING_CMD_OFFSET:
-            motorcontrol_config.commutation_angle_offset = tuning_mode_state.value;
+            torque_control_config.commutation_angle_offset = tuning_mode_state.value;
             break;
         case TUNING_CMD_PHASES_INVERTED:
             if (tuning_mode_state.value) {
-                motorcontrol_config.phases_inverted = MOTOR_PHASES_INVERTED;
+                torque_control_config.phases_inverted = MOTOR_PHASES_INVERTED;
             } else {
-                motorcontrol_config.phases_inverted = MOTOR_PHASES_NORMAL;
+                torque_control_config.phases_inverted = MOTOR_PHASES_NORMAL;
             }
             break;
         case TUNING_CMD_RATED_TORQUE:
-            motorcontrol_config.rated_torque = tuning_mode_state.value;
+            torque_control_config.rated_torque = tuning_mode_state.value;
             break;
         }
 
@@ -271,7 +271,7 @@ void tuning_command_handler(
         if (tuning_mode_state.command & TUNING_CMD_SET_MOTOR_CONTROL_MASK) {
             tuning_mode_state.brake_flag = 0;
             tuning_mode_state.motorctrl_status = TUNING_MOTORCTRL_OFF;
-            i_motion_control.set_motorcontrol_config(motorcontrol_config);
+            i_motion_control.set_motorcontrol_config(torque_control_config);
         }
 
     } else { //action command
@@ -334,7 +334,7 @@ void tuning_command_handler(
         case TUNING_CMD_AUTO_OFFSET:
             tuning_mode_state.motorctrl_status = TUNING_MOTORCTRL_OFF;
             tuning_mode_state.brake_flag = 0;
-            motorcontrol_config = i_motion_control.set_offset_detection_enabled();
+            torque_control_config = i_motion_control.set_offset_detection_enabled();
             break;
 
         //start position control auto tuning
@@ -469,16 +469,16 @@ void tuning_command_handler(
 
         case TUNING_CMD_SAVE_RECORD_COGGING:
 
-            motorcontrol_config = i_motion_control.get_motorcontrol_config();
-            i_file_service.write_torque_array(motorcontrol_config.torque_offset);
+            torque_control_config = i_motion_control.get_motorcontrol_config();
+            i_file_service.write_torque_array(torque_control_config.torque_offset);
 
             break;
 
         case TUNING_CMD_LOAD_RECORD_COGGING:
 
-            motorcontrol_config = i_motion_control.get_motorcontrol_config();
-            i_file_service.read_torque_array(motorcontrol_config.torque_offset);
-            i_motion_control.set_motorcontrol_config(motorcontrol_config);
+            torque_control_config = i_motion_control.get_motorcontrol_config();
+            i_file_service.read_torque_array(torque_control_config.torque_offset);
+            i_motion_control.set_motorcontrol_config(torque_control_config);
 
             break;
 
@@ -487,7 +487,7 @@ void tuning_command_handler(
 }
 
 uint8_t tuning_set_flags(TuningModeState &tuning_mode_state,
-        MotorcontrolConfig       &motorcontrol_config,
+        MotorcontrolConfig       &torque_control_config,
         MotionControlConfig      &motion_ctrl_config,
         PositionFeedbackConfig   &pos_feedback_config_1,
         PositionFeedbackConfig   &pos_feedback_config_2,
@@ -507,7 +507,7 @@ uint8_t tuning_set_flags(TuningModeState &tuning_mode_state,
         sensor_polarity = 0;
     }
     int phases_inverted = 0;
-    if (motorcontrol_config.phases_inverted == MOTOR_PHASES_INVERTED) {
+    if (torque_control_config.phases_inverted == MOTOR_PHASES_INVERTED) {
         phases_inverted = 1;
     }
     int integrated_profiler = 0;


### PR DESCRIPTION
This branch was started to help fixing the pwm timing issue. In the end the changes are mostly cleanups no really related to the bug but to simplify the network drive service and remove unnecessary call to the torque controller.

- Remove torque control interface from network drive
Now set/get config and reset fault for the torque control are done through
the motion control interface.
Also removed the call to set brake when opmode is not set because in this case the motorcontrol is already disabled.

- cleanup of unused code in network drive
