### PR TITLE
Fix bug when entering float numbers in app_demo_master_tuning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 sc_sncn_ethercat_drive Change Log
 ==================================
 
+3.2.1
+-----
+  * Fix bug when entering float numbers in app_demo_master_tuning
+
 3.2.0
 -----
 

--- a/examples/app_demo_master_ethercat_tuning/src/tuning.c
+++ b/examples/app_demo_master_ethercat_tuning/src/tuning.c
@@ -131,7 +131,11 @@ void tuning_command(WINDOW *wnd, struct _pdo_cia402_output *pdo_output, struct _
             pdo_output->target_torque = 0;
         } else { //normal 0
             (*cursor).col = draw(wnd, c, (*cursor).row, (*cursor).col); // draw the character
-            output->value *= 10;
+            if (output->float_count == 0) {
+                output->value *= 10;
+            } else {
+                output->float_count *= 10;
+            }
         }
         break;
 


### PR DESCRIPTION
The 0 after the dot were ignored (so 0.01 was transformed to 0.1).

It was because in the ethercat tuning app entering one 0 without pressing enter after is used as a quick way to stop the motor by switching to torque control and setting the torque to 0. So the character 0 has a special case and I forgot to update this case when I added float support.