### PR TITLE
Fix bug with dirty content after string upload

### DIFF
--- a/module_canopen_interface/src/canopen_interface_service.xc
+++ b/module_canopen_interface/src/canopen_interface_service.xc
@@ -178,7 +178,7 @@ void canopen_interface_service(
                         error = sdo_entry_set_value(index_, subindex, (uint8_t *)&tmpvalue, sizeof(uint16_t), REQUEST_FROM_APP);
                     } else {
                         size_t bytecount = sdo_entry_get_bytecount(index_, subindex);
-                        uint8_t tmpvalue[MAX_VALUE_BUFFER];
+                        uint8_t tmpvalue[MAX_VALUE_BUFFER] = { 0 };
                         memcpy(&tmpvalue, value, capacity);
                         error = sdo_entry_set_value(index_, subindex, (uint8_t *)&tmpvalue, bytecount, request_from);
                     }


### PR DESCRIPTION
There was some old values still present in the buffer, 0 initialization
on declaration solved this issue.